### PR TITLE
Always play Frost Lick sound for magic dispellers

### DIFF
--- a/TrialOfValor/Guarm.lua
+++ b/TrialOfValor/Guarm.lua
@@ -136,7 +136,7 @@ do
 		end
 		list[#list+1] = args.destName
 		if #list == 1 then
-			self:ScheduleTimer("TargetMessage", 0.4, args.spellId, list, "Urgent", "Alarm")
+			self:ScheduleTimer("TargetMessage", 0.4, args.spellId, list, "Urgent", "Alarm", nil, nil, self:Dispeller("magic"))
 		end
 	end
 end


### PR DESCRIPTION
The Frost Lick debuff should always play its alert sound if the player can dispell it.

Not sure about the other two, might also be useful is the player is a healer.