### PR TITLE
TombOfSargers/Goroth: Fix a self:Message() call

### DIFF
--- a/TombOfSargeras/Goroth.lua
+++ b/TombOfSargeras/Goroth.lua
@@ -129,7 +129,7 @@ end
 
 function mod:MeltedArmorRemoved(args)
 	if self:Me(args.destGUID) then
-		self:Message(args.spellId, "Urgent", "Warning", CL.removed:format(args.spellName))
+		self:Message(231363, "Urgent", "Warning", CL.removed:format(args.spellName))
 	end
 end
 


### PR DESCRIPTION
I knew I missed something important. I thought the first argument was there to fetch an icon, but after skimming through BossPrototype.lua I found out that it's there to check whether an option is enabled. So I replaced `args.spellId` with that of Burning Armor, since it's a single mechanic anyway and making a separate option does not make much sense to me, plus Infusion in the Maiden's module is handled similarly.