### PR TITLE
Core/BossPrototype: add :MythicPlus API call

### DIFF
--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -911,6 +911,12 @@ function boss:Mythic()
 	return difficulty == 16 or difficulty == 23
 end
 
+--- Check if in a Mythic keystone difficulty instance.
+-- @return boolean
+function boss:ChallengeMode()
+	return difficulty == 8
+end
+
 --- Get the mob/npc id from a GUID.
 -- @string guid GUID of a mob/npc
 -- @return mob id

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -913,7 +913,7 @@ end
 
 --- Check if in a Mythic keystone difficulty instance.
 -- @return boolean
-function boss:ChallengeMode()
+function boss:MythicPlus()
 	return difficulty == 8
 end
 


### PR DESCRIPTION
Some mechanics work slightly differently in M+. As an example, Dreadlord's Guise in BRH is even faster than it is on regular Mythic.