### PR TITLE
Plugins/AutoReply: add missing normal wipe example

### DIFF
--- a/Plugins/AutoReply.lua
+++ b/Plugins/AutoReply.lua
@@ -57,7 +57,7 @@ do
 		values = {
 			L.none,
 			L.autoReplyLeftCombatBasic,
-			L.autoReplyLeftCombatNormalWin:format(hogger),
+			"|cFF00FF00".. L.autoReplyLeftCombatNormalWin:format(hogger) .."|r   |cFFFF0000".. L.autoReplyLeftCombatNormalWipe:format(hogger) .. "|r",
 			"|cFF00FF00".. L.autoReplyLeftCombatAdvancedWin:format(hogger, 1, 20) .."|r   |cFFFF0000".. L.autoReplyLeftCombatAdvancedWipe:format(hogger, L.healthFormat:format(hogger, 0.1)) .."|r",
 		},
 		width = "full",


### PR DESCRIPTION
The example for the normal wipe message is missing in the options menu.

Color also the normal wipe/win messages like the advanced wipe/win messages in the options menu.