### PR TITLE
Update koKR.lua

### DIFF
--- a/Antorus/Locales/koKR.lua
+++ b/Antorus/Locales/koKR.lua
@@ -47,7 +47,7 @@ if L then
 	L.timeLeft = "%.1fs" -- s = seconds
 	L.torment = "티탄의 고통: %s"
 	L.nextTorment = "다음 : |cffffffff%s|r"
-	L.tormentHeal = "힐/도트" -- something like Heal/DoT (max 10 characters)
+	L.tormentHeal = "아만툴" -- something like Heal/DoT (max 10 characters)
 	L.tormentLightning = "골가네스" -- short for "Chain Lightning" (or similar, max 10 characters)
 	L.tormentArmy = "노르간논" -- short for "Spectral Army of Norgannon" (or similar, max 10 characters)
 	L.tormentFlames = "카즈고로스" -- short for "Flames of Khaz'goroth" (or similar, max 10 characters)

--- a/Antorus/Locales/koKR.lua
+++ b/Antorus/Locales/koKR.lua
@@ -48,9 +48,9 @@ if L then
 	L.torment = "티탄의 고통: %s"
 	L.nextTorment = "다음 : |cffffffff%s|r"
 	L.tormentHeal = "힐/도트" -- something like Heal/DoT (max 10 characters)
-	L.tormentLightning = "산개" -- short for "Chain Lightning" (or similar, max 10 characters)
-	L.tormentArmy = "메즈" -- short for "Spectral Army of Norgannon" (or similar, max 10 characters)
-	L.tormentFlames = "불길" -- short for "Flames of Khaz'goroth" (or similar, max 10 characters)
+	L.tormentLightning = "골가네스" -- short for "Chain Lightning" (or similar, max 10 characters)
+	L.tormentArmy = "노르간논" -- short for "Spectral Army of Norgannon" (or similar, max 10 characters)
+	L.tormentFlames = "카즈고로스" -- short for "Flames of Khaz'goroth" (or similar, max 10 characters)
 end
 
 L = BigWigs:NewBossLocale("Eonar the Life-Binder", "koKR")


### PR DESCRIPTION
다음 티탄의 고통 알림을 표시할 때 '산개'나 '메즈' 등의 지시사항으로 나타내는 것보다 단순히 '골가네스', '노르간논'으로 표시하는게 오히려 더 직관적이라 생각됨.

