### PR TITLE
Update Vectis.lua

### DIFF
--- a/Uldir/Vectis.lua
+++ b/Uldir/Vectis.lua
@@ -347,7 +347,7 @@ function mod:Gestate(args)
 		self:Say(265212)
 	end
 	self:TargetMessage2(265212, "orange", args.destName)
-	self:PlaySound(265212, "alert", nil, args.destName)
+	self:PlaySound(265212, "alert")
 	self:PrimaryIcon(265212, args.destName)
 	immunosuppressionCount = 1
 	self:CDBar(265206, 6, CL.count:format(self:SpellName(265206), immunosuppressionCount)) -- Immunosuppression


### PR DESCRIPTION
The PlaySound() in Gestate() was moved out of `if self:Me(args.destGUID) then`  (https://github.com/BigWigsMods/BigWigs/pull/563) however it needed the additional arguments (destGUID) removed from the PlaySound() call so that BigWigs_Voice can interpret the call properly as a general alert and play the correct sound file (rather than playing none at all)
