### PR TITLE
Core/BossPrototype: Add Throttle function

### DIFF
--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -1155,10 +1155,10 @@ function boss:Solo()
 	return solo
 end
 
--- Runs a function immediately if one with the same key has not been run recently. If a has been run within a number seconds, this does nothing.
+-- Runs a function immediately if one with the same key has not been run within a specified number of seconds. If it has been run, this does nothing.
 -- @param key the option key
 -- @number rate time, in seconds, that must pass before the function can be run again
--- @param func function that will be run if enough time has elapsed, passed (self).
+-- @param func function that will be run if enough time has elapsed, passed (self)
 function boss:Throttle(key, rate, func)
 	if not self.throttled then self.throttled = {} end
 	local prev = self.throttled[key]

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -290,6 +290,7 @@ function boss:Disable(isWipe)
 		self.missing = nil
 		self.isWiping = nil
 		self.isEngaged = nil
+		self.throttled = nil
 
 		self:CancelAllTimers()
 
@@ -1152,6 +1153,20 @@ end
 -- @return boolean
 function boss:Solo()
 	return solo
+end
+
+-- Runs a function immediately if it hasn't been run recently. If it has been run within a number seconds, nothing happens.
+-- @param key the option key
+-- @number rate time, in seconds, that must pass before the function can be run again
+-- @param func function that will be run if enough time has elapsed since the previous call with the same key, passed (self).
+function boss:Throttle(key, rate, func)
+	if not self.throttled then self.throttled = {} end
+	local prev = self.throttled[key]
+	local t = GetTime()
+	if not prev or t - prev > rate then
+		self.throttled[key] = t
+		func(self)
+	end
 end
 
 -------------------------------------------------------------------------------

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -1155,10 +1155,10 @@ function boss:Solo()
 	return solo
 end
 
--- Runs a function immediately if it hasn't been run recently. If it has been run within a number seconds, nothing happens.
+-- Runs a function immediately if one with the same key has not been run recently. If a has been run within a number seconds, this does nothing.
 -- @param key the option key
 -- @number rate time, in seconds, that must pass before the function can be run again
--- @param func function that will be run if enough time has elapsed since the previous call with the same key, passed (self).
+-- @param func function that will be run if enough time has elapsed, passed (self).
 function boss:Throttle(key, rate, func)
 	if not self.throttled then self.throttled = {} end
 	local prev = self.throttled[key]

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -1155,18 +1155,20 @@ function boss:Solo()
 	return solo
 end
 
--- Runs a function immediately if one with the same key has not been run within a specified number of seconds. If it has been run, this does nothing.
+-- Returns true if true has not been returned within rate seconds for the key, otherwise false.
 -- @param key the option key
 -- @number rate time, in seconds, that must pass before the function can be run again
--- @param func function that will be run if enough time has elapsed, passed (self)
-function boss:Throttle(key, rate, func)
+-- @number[opt] current time. GetTime will be used otherwise.
+-- @return boolean
+function boss:Throttle(key, rate, time)
 	if not self.throttled then self.throttled = {} end
 	local prev = self.throttled[key]
-	local t = GetTime()
+	local t = time or GetTime()
 	if not prev or t - prev > rate then
 		self.throttled[key] = t
-		func(self)
+		return true
 	end
+	return false
 end
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The following pattern occurs [very](https://github.com/BigWigsMods/LittleWigs/search?q=prev&unscoped_q=prev) [frequently](https://github.com/BigWigsMods/BigWigs/search?q=prev&unscoped_q=prev) for throttling messages from spells that are all cast in rapid succession.
```Lua
do
	local prev = 0
	function mod:AnAbility(args)
		local t = args.time
		if t-prev > 2 then
			prev = t
			-- do stuff
		end
	end
end
```

This could be rewritten as:
```Lua
function mod:AnAbility(args)
	if self:Throttle(args.spellId, 2, args.time) then
	-- or this: if not self:Throttle(args.spellId, 2, args.time) then return end
		-- do stuff
	end
end
```