### PR TITLE
BattleOfDazaralor/Council: Add timers for the wrath abilities

### DIFF
--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -200,23 +200,30 @@ function mod:LaceratingClawsApplied(args)
 end
 
 do
-	local prev = 0
-	local playerList = mod:NewTargetList()
+	local scheduled, isOnMe = nil, nil
+	local function announce()
+		if not isOnMe then -- Already announced if it was on me
+			mod:Message2(282834, "yellow")
+			mod:PlaySound(282834, "alert")
+		end
+		scheduled = nil
+		isOnMe = nil
+	end
+
 	function mod:KimbulsWrathApplied(args)
-		local t = args.time
-		if t-prev > 2 then
-			prev = t
-			self:Message2(args.spellId, "yellow")
-			self:PlaySound(args.spellId, "alert")
+		if not scheduled then
+			scheduled = true
 			self:Bar(args.spellId, 60)
+			self:SimpleTimer(announce, 0.1)
 		end
 		if self:Me(args.destGUID) then
+			isOnMe = true
+			self:PersonalMessage(args.spellId)
+			self:PlaySound(args.spellId, "warning")
 			self:Say(args.spellId)
 			self:Flash(args.spellId)
 			self:OpenProximity(args.spellId, 5)
 		end
-		playerList[#playerList+1] = args.destName
-		self:TargetsMessage(args.spellId, "orange", playerList)
 	end
 end
 

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -56,6 +56,8 @@ function mod:GetOptions()
 end
 
 function mod:OnBossEnable()
+	self:RegisterEvent("CHAT_MSG_RAID_BOSS_EMOTE")
+
 	-- General
 	self:Log("SPELL_AURA_APPLIED", "LoasWrath", 282736)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "LoasWrath", 282736)
@@ -66,7 +68,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "GiftofWind", 282098)
 	self:Log("SPELL_AURA_APPLIED", "HasteningWinds", 285945)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "HasteningWinds", 285945)
-	self:Log("SPELL_CAST_START", "PakusWrath", 282107)
 
 	-- Gonk's Aspect
 	self:Log("SPELL_CAST_START", "CrawlingHex", 283193)
@@ -99,6 +100,14 @@ end
 -- Event Handlers
 --
 
+function mod:CHAT_MSG_RAID_BOSS_EMOTE(_, msg)
+	if msg:find("282107", nil, true) then -- Pa'ku's Wrath
+		self:Message2(282107, "red")
+		self:PlaySound(282107, "warning")
+		self:Bar(282107, 60)
+	end
+end
+
 function mod:LoasWrath(args)
 	self:StackMessage(args.spellId, args.destName, args.amount, "cyan")
 	self:PlaySound(args.spellId, "info")
@@ -127,11 +136,6 @@ function mod:HasteningWinds(args)
 		self:StackMessage(args.spellId, args.destName, args.amount, "purple")
 		self:PlaySound(args.spellId, "alarm", nil, args.destName)
 	end
-end
-
-function mod:PakusWrath(args)
-	self:Message2(args.spellId, "red")
-	self:PlaySound(args.spellId, "warning")
 end
 
 function mod:CrawlingHex(args)

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -276,6 +276,6 @@ function mod:BossDeath(args)
 	if bossesKilled == 1 then -- Kimbul spawning
 		self:Bar(282834, 49) -- Kimbul's Wrath XXX check this
 	elseif bossesKilled == 2 then -- Akunda spawning
-		self:Bar(286811, 33) -- Akunda's Wrath XXX check this
+		self:Bar(286811, 20) -- Akunda's Wrath XXX check this
 	end
 end

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -94,6 +94,7 @@ function mod:OnEngage()
 	self:CDBar(282098, 5) -- Gift of Wind
 	self:CDBar(282135, 13.5) -- Crawling Hex
 	self:CDBar(285893, 17) -- Wild Maul
+	self:Bar(282107, 60) -- Pa'ku's Wrath
 end
 
 --------------------------------------------------------------------------------

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -74,8 +74,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "CrawlingHexApplied", 282135)
 	self:Log("SPELL_AURA_REMOVED", "CrawlingHexRemoved", 282135)
 	self:Log("SPELL_CAST_SUCCESS", "WildMaul", 285893)
-	self:Log("SPELL_CAST_START", "GonksWrath", 282155)
-	self:Log("SPELL_AURA_APPLIED", "MarkofPrey", 282209)
+	self:Log("SPELL_AURA_APPLIED", "MarkofPrey", 282209) -- Used for Gonk's Wrath as well
 
 	-- Kimbul's Aspect
 	self:Log("SPELL_CAST_START", "LaceratingClaws", 282444)
@@ -170,17 +169,22 @@ function mod:WildMaul(args)
 	self:CDBar(args.spellId, 17)
 end
 
-function mod:GonksWrath(args)
-	self:Message2(args.spellId, "cyan")
-	self:PlaySound(args.spellId, "info")
-end
-
-function mod:MarkofPrey(args)
-	if self:Me(args.destGUID) then
-		self:PersonalMessage(args.spellId)
-		self:PlaySound(args.spellId, "warning")
-		self:Flash(args.spellId)
-		self:Say(args.spellId)
+do
+	local prev = 0
+	function mod:MarkofPrey(args)
+		local t = args.time
+		if t-prev > 50 then
+			prev = t
+			self:Message2(282155, "cyan") -- Gonk's Wrath
+			self:PlaySound(282155, "info") -- Gonk's Wrath
+			self:Bar(282155, 60) -- Gonk's Wrath
+		end
+		if self:Me(args.destGUID) then
+			self:PersonalMessage(args.spellId)
+			self:PlaySound(args.spellId, "warning")
+			self:Flash(args.spellId)
+			self:Say(args.spellId)
+		end
 	end
 end
 

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -274,7 +274,7 @@ end
 function mod:BossDeath(args)
 	bossesKilled = bossesKilled + 1
 	if bossesKilled == 1 then -- Kimbul spawning
-		self:Bar(282834, 49) -- Kimbul's Wrath XXX check this
+		self:Bar(282834, 50) -- Kimbul's Wrath XXX check this
 	elseif bossesKilled == 2 then -- Akunda spawning
 		self:Bar(286811, 20) -- Akunda's Wrath XXX check this
 	end

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -177,7 +177,7 @@ do
 		-- Gonk's Wrath isn't in the combat log
 		-- Instead, throttle the debuff that the raptors apply immediately
 		local t = args.time
-		if t-prev > 50 then
+		if t-prev > 58 then
 			prev = t
 			self:Message2(282155, "cyan") -- Gonk's Wrath
 			self:PlaySound(282155, "info") -- Gonk's Wrath

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -209,11 +209,11 @@ do
 			self:Message2(args.spellId, "yellow")
 			self:PlaySound(args.spellId, "alert")
 			self:Bar(args.spellId, 60)
-			self:OpenProximity(args.spellId, 5)
 		end
 		if self:Me(args.destGUID) then
 			self:Say(args.spellId)
 			self:Flash(args.spellId)
+			self:OpenProximity(args.spellId, 5)
 		end
 		playerList[#playerList+1] = args.destName
 		self:TargetsMessage(args.spellId, "orange", playerList)

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -172,6 +172,8 @@ end
 do
 	local prev = 0
 	function mod:MarkofPrey(args)
+		-- Gonk's Wrath isn't in the combat log
+		-- Instead, throttle the debuff that the raptors apply immediately
 		local t = args.time
 		if t-prev > 50 then
 			prev = t

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -232,6 +232,7 @@ function mod:MindWipe(args)
 end
 
 function mod:AkundasWrathApplied(args)
+	self:Bar(args.spellId, 60)
 	if self:Me(args.destGUID) then
 		self:PlaySound(args.spellId, "warning")
 		self:Say(args.spellId)

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -271,8 +271,8 @@ end
 function mod:BossDeath(args)
 	bossesKilled = bossesKilled + 1
 	if bossesKilled == 1 then -- Kimbul spawning
-		-- XXX Kimbul's Wrath timer here
+		self:Bar(282834, 49) -- Kimbul's Wrath XXX check this
 	elseif bossesKilled == 2 then -- Akunda spawning
-		-- XXX Akunda's Wrath timer here
+		self:Bar(286811, 33) -- Akunda's Wrath XXX check this
 	end
 end

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -94,7 +94,8 @@ function mod:OnEngage()
 	self:CDBar(282098, 5) -- Gift of Wind
 	self:CDBar(282135, 13.5) -- Crawling Hex
 	self:CDBar(285893, 17) -- Wild Maul
-	self:Bar(282107, 60) -- Pa'ku's Wrath
+	self:Bar(282107, 73) -- Pa'ku's Wrath
+	self:Bar(282155, 31) -- Gonk's Wrath
 end
 
 --------------------------------------------------------------------------------

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -106,6 +106,7 @@ function mod:CHAT_MSG_RAID_BOSS_EMOTE(_, msg)
 		self:Message2(282107, "red")
 		self:PlaySound(282107, "warning")
 		self:Bar(282107, 60)
+		self:CastBar(282107, 5)
 	end
 end
 

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -17,6 +17,8 @@ mod.respawnTime = 30
 -- Locals
 --
 
+local bossesKilled = 0
+
 --------------------------------------------------------------------------------
 -- Localization
 --
@@ -88,9 +90,12 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "MindWipe", 285878)
 	self:Log("SPELL_AURA_APPLIED", "AkundasWrathApplied", 286811)
 	self:Log("SPELL_AURA_REMOVED", "AkundasWrathRemoved", 286811)
+
+	self:Death("BossDeath", 144747, 144767, 144963, 144941) -- Pa'ku's Aspect, Gonk's Aspect, Kimbul's Aspect, Akunda's Aspect)
 end
 
 function mod:OnEngage()
+	bossesKilled = 0
 	self:CDBar(282098, 5) -- Gift of Wind
 	self:CDBar(282135, 13.5) -- Crawling Hex
 	self:CDBar(285893, 17) -- Wild Maul
@@ -260,5 +265,14 @@ end
 function mod:AkundasWrathRemoved(args)
 	if self:Me(args.destGUID) then
 		self:CancelSayCountdown(args.spellId)
+	end
+end
+
+function mod:BossDeath(args)
+	bossesKilled = bossesKilled + 1
+	if bossesKilled == 1 then -- Kimbul spawning
+		-- XXX Kimbul's Wrath timer here
+	elseif bossesKilled == 2 then -- Akunda spawning
+		-- XXX Akunda's Wrath timer here
 	end
 end

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -81,7 +81,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "LaceratingClaws", 282444)
 	self:Log("SPELL_AURA_APPLIED", "LaceratingClawsApplied", 282444)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "LaceratingClawsApplied", 282444)
-	self:Log("SPELL_CAST_SUCCESS", "KimbulsWrath", 282447)
+	self:Log("SPELL_AURA_APPLIED", "KimbulsWrathApplied", 282834)
 
 	-- Akunda's Aspect
 	self:Log("SPELL_CAST_START", "ThunderingStorm", 282411)
@@ -192,9 +192,17 @@ function mod:LaceratingClawsApplied(args)
 	self:PlaySound(args.spellId, "alarm", nil, args.destName)
 end
 
-function mod:KimbulsWrath(args)
-	self:Message2(args.spellId, "yellow")
-	self:PlaySound(args.spellId, "alert")
+do
+	local prev = 0
+	function mod:KimbulsWrathApplied(args)
+		local t = args.time
+		if t-prev > 2 then
+			prev = t
+			self:Message2(args.spellId, "yellow")
+			self:PlaySound(args.spellId, "alert")
+			self:Bar(args.spellId, 60)
+		end
+	end
 end
 
 function mod:ThunderingStorm(args)

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -102,7 +102,7 @@ end
 --
 
 function mod:CHAT_MSG_RAID_BOSS_EMOTE(_, msg)
-	if msg:find("282107", nil, true) then -- Pa'ku's Wrath
+	if msg:find("282107", nil, true) then -- Pa'ku's Wrath, not in the combat log
 		self:Message2(282107, "red")
 		self:PlaySound(282107, "warning")
 		self:Bar(282107, 60)

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -47,7 +47,7 @@ function mod:GetOptions()
 		{282209, "SAY", "FLASH"}, -- Mark of Prey
 		-- Kimbul's Aspect
 		{282444, "TANK"}, -- Lacerating Claws
-		{282834, "SAY", "PROXIMITY"}, -- Kimbul's Wrath
+		{282834, "SAY", "FLASH", "PROXIMITY"}, -- Kimbul's Wrath
 		-- Akunda's Aspect
 		282411, -- Thundering Storm
 		285878, -- Mind Wipe
@@ -211,6 +211,7 @@ do
 		end
 		if self:Me(args.destGUID) then
 			self:Say(args.spellId)
+			self:Flash(args.spellId)
 		end
 		playerList[#playerList+1] = args.destName
 		self:TargetsMessage(args.spellId, "orange", playerList)

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -117,8 +117,11 @@ function mod:CHAT_MSG_RAID_BOSS_EMOTE(_, msg)
 end
 
 function mod:LoasWrath(args)
-	self:StackMessage(args.spellId, args.destName, args.amount, "cyan")
-	self:PlaySound(args.spellId, "info")
+	local unit = self:GetBossByGUID(args.destGUID)
+	if unit and not UnitIsDead(unit) then
+		self:StackMessage(args.spellId, args.destName, args.amount, "cyan")
+		self:PlaySound(args.spellId, "info")
+	end
 end
 
 function mod:LoasPact(args)

--- a/BattleOfDazaralor/Council.lua
+++ b/BattleOfDazaralor/Council.lua
@@ -47,7 +47,7 @@ function mod:GetOptions()
 		{282209, "SAY", "FLASH"}, -- Mark of Prey
 		-- Kimbul's Aspect
 		{282444, "TANK"}, -- Lacerating Claws
-		282447, -- Kimbul's Wrath
+		{282834, "SAY", "PROXIMITY"}, -- Kimbul's Wrath
 		-- Akunda's Aspect
 		282411, -- Thundering Storm
 		285878, -- Mind Wipe
@@ -82,6 +82,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "LaceratingClawsApplied", 282444)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "LaceratingClawsApplied", 282444)
 	self:Log("SPELL_AURA_APPLIED", "KimbulsWrathApplied", 282834)
+	self:Log("SPELL_AURA_REMOVED", "KimbulsWrathRemoved", 282834)
 
 	-- Akunda's Aspect
 	self:Log("SPELL_CAST_START", "ThunderingStorm", 282411)
@@ -194,6 +195,7 @@ end
 
 do
 	local prev = 0
+	local playerList = mod:NewTargetList()
 	function mod:KimbulsWrathApplied(args)
 		local t = args.time
 		if t-prev > 2 then
@@ -201,7 +203,19 @@ do
 			self:Message2(args.spellId, "yellow")
 			self:PlaySound(args.spellId, "alert")
 			self:Bar(args.spellId, 60)
+			self:OpenProximity(args.spellId, 5)
 		end
+		if self:Me(args.destGUID) then
+			self:Say(args.spellId)
+		end
+		playerList[#playerList+1] = args.destName
+		self:TargetsMessage(args.spellId, "orange", playerList)
+	end
+end
+
+function mod:KimbulsWrathRemoved(args)
+	if self:Me(args.destGUID) then
+		self:CloseProximity(args.spellId)
 	end
 end
 


### PR DESCRIPTION
The January 26th commits aren't tested yet. I'll post a comment later today or tomorrow when it's tested and working.

- Add timers for Gonk's Wrath, Pa'ku's Wrath, Kimbul's Wrath, Akunda's Wrath
- Add range check for people targeted by Kimbul's Wrath
- Don't show Loa's Wrath messages for dead bosses