### PR TITLE
BattleOfDazaralor/Jadefire: Fix number of searing embers

### DIFF
--- a/BattleOfDazaralor/JadefireAlliance.lua
+++ b/BattleOfDazaralor/JadefireAlliance.lua
@@ -337,7 +337,7 @@ do
 		if self:GetOption(searingEmbersMarker) then
 			SetRaidTarget(args.destName, playerIconsCount)
 		end
-		self:TargetsMessage(args.spellId, "orange", playerList, 4, nil, nil, nil, playerIcons)
+		self:TargetsMessage(args.spellId, "orange", playerList, self:Easy() and 3 or 4, nil, nil, nil, playerIcons)
 	end
 
 	function mod:SearingEmbersRemoved(args)

--- a/BattleOfDazaralor/JadefireAlliance.lua
+++ b/BattleOfDazaralor/JadefireAlliance.lua
@@ -39,7 +39,7 @@ end
 -- Initialization
 --
 
-local searingEmbersMarker = mod:AddMarkerOption(false, "player", 1, 286988, 1, 2, 3) -- Searing Embers
+local searingEmbersMarker = mod:AddMarkerOption(false, "player", 1, 286988, 1, 2, 3, 4) -- Searing Embers
 function mod:GetOptions()
 	return {
 		"stages",
@@ -337,7 +337,7 @@ do
 		if self:GetOption(searingEmbersMarker) then
 			SetRaidTarget(args.destName, playerIconsCount)
 		end
-		self:TargetsMessage(args.spellId, "orange", playerList, 3, nil, nil, nil, playerIcons)
+		self:TargetsMessage(args.spellId, "orange", playerList, 4, nil, nil, nil, playerIcons)
 	end
 
 	function mod:SearingEmbersRemoved(args)

--- a/BattleOfDazaralor/JadefireHorde.lua
+++ b/BattleOfDazaralor/JadefireHorde.lua
@@ -337,7 +337,7 @@ do
 		if self:GetOption(searingEmbersMarker) then
 			SetRaidTarget(args.destName, playerIconsCount)
 		end
-		self:TargetsMessage(args.spellId, "orange", playerList, 4, nil, nil, nil, playerIcons)
+		self:TargetsMessage(args.spellId, "orange", playerList, self:Easy() and 3 or 4, nil, nil, nil, playerIcons)
 	end
 
 	function mod:SearingEmbersRemoved(args)

--- a/BattleOfDazaralor/JadefireHorde.lua
+++ b/BattleOfDazaralor/JadefireHorde.lua
@@ -39,7 +39,7 @@ end
 -- Initialization
 --
 
-local searingEmbersMarker = mod:AddMarkerOption(false, "player", 1, 286988, 1, 2, 3) -- Searing Embers
+local searingEmbersMarker = mod:AddMarkerOption(false, "player", 1, 286988, 1, 2, 3, 4) -- Searing Embers
 function mod:GetOptions()
 	return {
 		"stages",
@@ -337,7 +337,7 @@ do
 		if self:GetOption(searingEmbersMarker) then
 			SetRaidTarget(args.destName, playerIconsCount)
 		end
-		self:TargetsMessage(args.spellId, "orange", playerList, 3, nil, nil, nil, playerIcons)
+		self:TargetsMessage(args.spellId, "orange", playerList, 4, nil, nil, nil, playerIcons)
 	end
 
 	function mod:SearingEmbersRemoved(args)


### PR DESCRIPTION
Normal has 2 to 3 debuffs, depending on raid side. Heroic has 2 to 4. Mythic has 4.