### PR TITLE
BattleOfDazaralor/Conclave: Updates Wrath timers

### DIFF
--- a/BattleOfDazaralor/Conclave.lua
+++ b/BattleOfDazaralor/Conclave.lua
@@ -144,19 +144,19 @@ function mod:OnEngage()
 	lastBossKillNextAspect = 0
 	lastWrathBarTime = 0
 	lastWrathBar = { 
-		[282155] = 0,  -- Gonk
+		[282155] = GetTime(),  -- Gonk
 		[282107] = 0,  -- Paku
 		[282447] = 0,  -- Kimbul
 		[286811] = 0,  -- Akunda 
 	}
+
 	self:Bar(282098, 5) -- Gift of Wind
 	self:CDBar(282135, 13) -- Crawling Hex
 	self:CDBar(285893, 17) -- Wild Maul
 	if not self:Easy() then
 		self:CDBar(282636, 29) -- Krag'wa's Wrath
 	end
-	self:CDBar(282155, spawnCooldown + wrathOffset[282155])  -- Gonk always spawns first
-	lastWrathBar[282155] = GetTime()
+	self:CDBar(282155, spawnCooldown)  -- Gonk always spawns first
 end
 
 function mod:OnBossDisable()
@@ -241,12 +241,12 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 
 		-- Start bars
 		if bossesKilled == 1 then -- Kimbul spawning
-			self:Bar(282444, 20.5) -- Lacerating Claws
 			spawnCooldown = 20
+			self:Bar(282444, 20.5) -- Lacerating Claws
 		elseif bossesKilled == 2 then -- Akunda spawning
+			spawnCooldown = 15
 			self:Bar(285879, 5) -- Mind Wipe
 			self:Bar(282411, 16) -- Thundering Storm
-			spawnCooldown = 15
 		end
 	elseif spellId == 283193 then -- Crawling Hex
 		self:CrawlingHexSuccess()

--- a/BattleOfDazaralor/Conclave.lua
+++ b/BattleOfDazaralor/Conclave.lua
@@ -200,13 +200,13 @@ function mod:NextWrathCDBar(spellId)
 		-- If the last boss was killed between the aspect spawn and the wrath, 
 		-- reconstruct the situation at spawn time.
 		offset = offset + wrathOffset[lastBossKillNextAspect]
-		self:CDBar(lastBossKillNextAspect, lastBossKillSpawnCooldown + offset)
+		self:CDBar(lastBossKillNextAspect, lastBossKillSpawnCooldown + offset) -- SetOption:282107,282155,282447,286811:::
 		lastWrathBar[lastBossKillNextAspect] = now
 	else
 		local nextAspect = self:NextAspect()
 		offset = offset + wrathOffset[nextAspect]
-    		self:CDBar(nextAspect, spawnCooldown + offset)
-    		lastWrathBar[nextAspect] = now
+		self:CDBar(nextAspect, spawnCooldown + offset) -- SetOption:282107,282155,282447,286811:::
+		lastWrathBar[nextAspect] = now
 	end
 end
 

--- a/BattleOfDazaralor/Conclave.lua
+++ b/BattleOfDazaralor/Conclave.lua
@@ -156,7 +156,7 @@ function mod:OnEngage()
 	if not self:Easy() then
 		self:CDBar(282636, 29) -- Krag'wa's Wrath
 	end
-	self:CDBar(282155, spawnCooldown)  -- Gonk always spawns first
+	self:CDBar(282155, spawnCooldown + wrathOffset[282155])  -- Gonk always spawns first
 end
 
 function mod:OnBossDisable()


### PR DESCRIPTION
Wraths occur with a constant but aspect specific offset to the spawn timers. Initially, spawn timers are 30 seconds. Spawn timers are reduced to 20 and 15 seconds after one and two bosses die, respectively. From the active aspects, the one least recently seen spawns next. Spawn timers continue when a boss dies, hence the time between the same Wraths can be extended from 30 + 30 = 20 + 20 + 20 = 15 + 15 + 15 + 15 = 60 to 30 + 20 +20 = 70 or 20 + 15 + 15 + 15 =65 seconds.
With this change, Wrath timers are shorter and only one timer is active at a time. However, the minimal duration for Paku's Wrath is 13 + 15 = 28 seconds, which is long enough to prepare.