### PR TITLE
Fix #617  bigwigs local bars disappear on changing zones

### DIFF
--- a/Plugins/Bars.lua
+++ b/Plugins/Bars.lua
@@ -2024,7 +2024,7 @@ end
 SlashCmdList.BIGWIGSLOCALBAR = function(input)
 	if not plugin:IsEnabled() then BigWigs:Enable() end
 
-	local seconds, barText = input:match("(%S+) (.*)")
+	local seconds, barText = input:match("(%S+)%s*(.*)")
 	if not seconds or not barText then BigWigs:Print(L.wrongCustomBarFormat:gsub("/raidbar", "/localbar")) return end
 
 	seconds = parseTime(seconds)


### PR DESCRIPTION
I confirmed the issue occurred and tested my fix locally.

All the was involved with a small change in the regex for localbar to use %s* between counter and string.

To test, you can swap the Plugins/Bars.lua in my PR with the one in your Addons folder.