### PR TITLE
Core/BossPrototype: Add warlock felhunter purge and interrupt

### DIFF
--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -1278,8 +1278,8 @@ do
 			-- Soothe (Druid), Hunter pet
 			offDispel.enrage = true
 		end
-		if IsSpellKnown(527) or IsSpellKnown(77130) or IsSpellKnown(115450) or IsSpellKnown(4987) or IsSpellKnown(88423) or IsSpellKnown(89808, true) then -- XXX Add DPS priest mass dispel?
-			-- Purify (Heal Priest), Purify Spirit (Heal Shaman), Detox (Heal Monk), Cleanse (Heal Paladin), Nature's Cure (Heal Druid), Singe Magic (Warlock Imp)
+		if IsSpellKnown(527) or IsSpellKnown(77130) or IsSpellKnown(115450) or IsSpellKnown(4987) or IsSpellKnown(88423) then -- XXX Add DPS priest mass dispel?
+			-- Purify (Heal Priest), Purify Spirit (Heal Shaman), Detox (Heal Monk), Cleanse (Heal Paladin), Nature's Cure (Heal Druid)
 			defDispel.magic = true
 		end
 		if IsSpellKnown(527) or IsSpellKnown(213634) or IsSpellKnown(115450) or IsSpellKnown(218164) or IsSpellKnown(4987) or IsSpellKnown(213644) then

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -1306,7 +1306,8 @@ do
 			if not o then core:Print(format("Module %s uses %q as a dispel lookup, but it doesn't exist in the module options.", self.name, key)) return end
 			if band(o, C.DISPEL) ~= C.DISPEL then return true end
 		end
-		return isOffensive and offDispel[dispelType] or defDispel[dispelType]
+		local dispelTable = isOffensive and offDispel or defDispel
+		return dispelTable[dispelType]
 	end
 end
 

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -1278,8 +1278,8 @@ do
 			-- Soothe (Druid), Hunter pet
 			offDispel.enrage = true
 		end
-		if IsSpellKnown(32375) or IsSpellKnown(527) or IsSpellKnown(77130) or IsSpellKnown(115450) or IsSpellKnown(4987) or IsSpellKnown(88423) or IsSpellKnown(89808, true) then
-			-- Mass Dispel (Priest), Purify (Heal Priest), Purify Spirit (Heal Shaman), Detox (Heal Monk), Cleanse (Heal Paladin), Nature's Cure (Heal Druid), Singe Magic (Warlock Imp)
+		if IsSpellKnown(527) or IsSpellKnown(77130) or IsSpellKnown(115450) or IsSpellKnown(4987) or IsSpellKnown(88423) or IsSpellKnown(89808, true) then -- XXX Add DPS priest mass dispel?
+			-- Purify (Heal Priest), Purify Spirit (Heal Shaman), Detox (Heal Monk), Cleanse (Heal Paladin), Nature's Cure (Heal Druid), Singe Magic (Warlock Imp)
 			defDispel.magic = true
 		end
 		if IsSpellKnown(527) or IsSpellKnown(213634) or IsSpellKnown(115450) or IsSpellKnown(218164) or IsSpellKnown(4987) or IsSpellKnown(213644) then

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -1248,7 +1248,7 @@ function boss:Damager(unit)
 	end
 end
 
-petUtilityFrame:SetScript("OnEvent", function(_, event, unit)
+petUtilityFrame:SetScript("OnEvent", function()
 	UpdateDispelStatus()
 	UpdateInterruptStatus()
 end)

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -1278,8 +1278,8 @@ do
 			-- Soothe (Druid), Hunter pet
 			offDispel.enrage = true
 		end
-		if IsSpellKnown(527) or IsSpellKnown(77130) or IsSpellKnown(115450) or IsSpellKnown(4987) or IsSpellKnown(88423) or IsSpellKnown(89808, true) then -- XXX Add DPS priest mass dispel?
-			-- Purify (Heal Priest), Purify Spirit (Heal Shaman), Detox (Heal Monk), Cleanse (Heal Paladin), Nature's Cure (Heal Druid), Singe Magic (Warlock Imp)
+		if IsSpellKnown(32375) or IsSpellKnown(527) or IsSpellKnown(77130) or IsSpellKnown(115450) or IsSpellKnown(4987) or IsSpellKnown(88423) or IsSpellKnown(89808, true) then
+			-- Mass Dispel (Priest), Purify (Heal Priest), Purify Spirit (Heal Shaman), Detox (Heal Monk), Cleanse (Heal Paladin), Nature's Cure (Heal Druid), Singe Magic (Warlock Imp)
 			defDispel.magic = true
 		end
 		if IsSpellKnown(527) or IsSpellKnown(213634) or IsSpellKnown(115450) or IsSpellKnown(218164) or IsSpellKnown(4987) or IsSpellKnown(213644) then


### PR DESCRIPTION
Added spells:
- Devour Magic (Warlock Felhunter)
- Spell Lock (Warlock Felhunter)

Also fixed a bug causing Dispeller to return true for offensive magic dispels if a defensive magic dispel is available.