### PR TITLE
Options: Nameplate Bar option should only show for spells that use it

### DIFF
--- a/Nyalotha/NZoth.lua
+++ b/Nyalotha/NZoth.lua
@@ -65,7 +65,7 @@ function mod:GetOptions()
 		"altpower",
 		{313609, "SAY_COUNTDOWN"}, -- Gift of N'zoth
 		-- Stage 1
-		316711, -- Mindwrack
+		{316711, "NAMEPLATEBAR"}, -- Mindwrack
 		310184, -- Creeping Anquish
 		309991, -- Anguish
 		313184, -- Synaptic Shock
@@ -79,12 +79,12 @@ function mod:GetOptions()
 		312866, -- Cataclysmic Flames
 		{309698, "TANK"}, -- Void Lash
 		310042, -- Tumultuous Burst
-		313400, -- Corrupted Mind
+		{313400, "NAMEPLATEBAR"}, -- Corrupted Mind
 		-- Stage 3
 		318976, -- Stupefying Glare
 		317102, -- Evoke Anguish
 		-21491, -- Thought Harvester
-		317066, -- Harvest Thoughts
+		{317066, "NAMEPLATEBAR"}, -- Harvest Thoughts
 	}, {
 		["stages"] = CL.general,
 		[313609] = -20936, -- Sanity

--- a/Nyalotha/NZoth.lua
+++ b/Nyalotha/NZoth.lua
@@ -79,7 +79,7 @@ function mod:GetOptions()
 		312866, -- Cataclysmic Flames
 		{309698, "TANK"}, -- Void Lash
 		310042, -- Tumultuous Burst
-		{313400, "NAMEPLATEBAR"}, -- Corrupted Mind
+		313400, -- Corrupted Mind
 		-- Stage 3
 		318976, -- Stupefying Glare
 		317102, -- Evoke Anguish

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -396,6 +396,7 @@ local icons = {
 	SAY = 2056011, -- Interface\\Icons\\UI_Chat
 	SAY_COUNTDOWN = 2056011, -- Interface\\Icons\\UI_Chat
 	VOICE = 589118, -- Interface\\Icons\\Warrior_DisruptingShout
+	NAMEPLATEBAR = 134377, -- Interface\\Icons\\inv_misc_pocketwatch_02
 }
 
 local function hasOptionFlag(dbKey, module, key)
@@ -431,8 +432,11 @@ local function advancedToggles(dbKey, module, check)
 		-- Bars
 		advancedOptions[7] = getSlaveToggle(L.BAR, L.BAR_desc, dbKey, module, C.BAR, check)
 		advancedOptions[8] = getSlaveToggle(L.CASTBAR, L.CASTBAR_desc, dbKey, module, C.CASTBAR, check)
-		advancedOptions[9] = getSlaveToggle(L.NAMEPLATEBAR, L.NAMEPLATEBAR_desc, dbKey, module, C.NAMEPLATEBAR, check)
 		--
+	end
+
+	if bit.band(dbv, C.NAMEPLATEBAR) == C.NAMEPLATEBAR and hasOptionFlag(dbKey, module, "NAMEPLATEBAR") then
+		advancedOptions[#advancedOptions + 1] = getSlaveToggle(L.NAMEPLATEBAR, L.NAMEPLATEBAR_desc, dbKey, module, C.NAMEPLATEBAR, check, icons["NAMEPLATEBAR"])
 	end
 
 	-- Flash & Pulse
@@ -673,7 +677,7 @@ local function getDefaultToggleOption(scrollFrame, dropdown, module, bossOption)
 	local showFlags = {
 		"TANK_HEALER", "TANK", "HEALER", "DISPEL",
 		"EMPHASIZE", "ME_ONLY", "ME_ONLY_EMPHASIZE", "COUNTDOWN", "FLASH", "ICON", "SAY", "SAY_COUNTDOWN",
-		"PROXIMITY", "INFOBOX", "ALTPOWER",
+		"PROXIMITY", "INFOBOX", "ALTPOWER", "NAMEPLATEBAR",
 	}
 	for i = 1, #showFlags do
 		local key = showFlags[i]

--- a/gen_option_values.lua
+++ b/gen_option_values.lua
@@ -69,6 +69,12 @@ local valid_methods = {
 	SetInfo = "INFOBOX",
 	SetInfoBar = "INFOBOX",
 	CloseInfo = "INFOBOX",
+	NameplateBar = "NAMEPLATEBAR",
+	NameplateCDBar = "NAMEPLATEBAR",
+	PauseNameplateBar = "NAMEPLATEBAR",
+	ResumeNameplateBar = "NAMEPLATEBAR",
+	NameplateBarTimeLeft = "NAMEPLATEBAR",
+	StopNameplateBar = "NAMEPLATEBAR",
 }
 for k in next, color_methods do valid_methods[k] = true end
 for k in next, sound_methods do valid_methods[k] = true end


### PR DESCRIPTION
Adds NAMEPLATEBAR option flag. Icon is Inv_misc_pocketwatch_02 (134377).