### PR TITLE
MoltenCore/Ragnaros: add RP timer, first Wrath cast

### DIFF
--- a/MoltenCore/Options/Colors.lua
+++ b/MoltenCore/Options/Colors.lua
@@ -40,6 +40,7 @@ BigWigs:AddColors("Majordomo Executus", {
 
 BigWigs:AddColors("Ragnaros", {
 	[20566] = "red",
+	["pull_rp"] = "white",
 	["emerge"] = {"green","orange","yellow"},
 	["submerge"] = {"orange","yellow"},
 })

--- a/MoltenCore/Options/Colors.lua
+++ b/MoltenCore/Options/Colors.lua
@@ -40,7 +40,7 @@ BigWigs:AddColors("Majordomo Executus", {
 
 BigWigs:AddColors("Ragnaros", {
 	[20566] = "red",
-	["pull_rp"] = "white",
+	["pull_rp"] = "cyan",
 	["emerge"] = {"green","orange","yellow"},
 	["submerge"] = {"orange","yellow"},
 })

--- a/MoltenCore/Options/Colors.lua
+++ b/MoltenCore/Options/Colors.lua
@@ -40,7 +40,7 @@ BigWigs:AddColors("Majordomo Executus", {
 
 BigWigs:AddColors("Ragnaros", {
 	[20566] = "red",
-	["pull_rp"] = "cyan",
+	["warmup"] = "cyan",
 	["emerge"] = {"green","orange","yellow"},
 	["submerge"] = {"orange","yellow"},
 })

--- a/MoltenCore/Ragnaros.lua
+++ b/MoltenCore/Ragnaros.lua
@@ -115,11 +115,7 @@ end
 function mod:MajordomoDeath()
 	-- it takes exactly 10 seconds for combat to start after Majodromo dies, while
 	-- the time between starting the RP/summon and killing Majordomo varies
-	local remaining = self:BarTimeLeft("warmup")
-	if remaining ~= 10 then
-		self:StopBar("warmup")
-		self:Bar("warmup", 10, CL.active, L.warmup_icon)
-	end
+	self:Bar("warmup", 10, CL.active, L.warmup_icon)
 end
 
 function mod:Emerge()

--- a/MoltenCore/Ragnaros.lua
+++ b/MoltenCore/Ragnaros.lua
@@ -5,7 +5,7 @@
 
 local mod, CL = BigWigs:NewBoss("Ragnaros", 409)
 if not mod then return end
-mod:RegisterEnableMob(11502)
+mod:RegisterEnableMob(11502, 12018)
 mod:SetAllowWin(true)
 mod.engageId = 672
 
@@ -22,6 +22,12 @@ local timer = nil
 
 local L = mod:NewLocale("enUS", true)
 if L then
+	L.pull_rp = "RP timer"
+	L.pull_rp_desc = "Timer for the RP after engaging Majordomo"
+	L.pull_rp_icon = "spell_fire_lavaspawn"
+	L.pull_rp_message = "Pull RP started, engaging in ~73s"
+	L.pull_rp_bar = "Encounter starting"
+
 	L.engage_trigger = "NOW FOR YOU,"
 	L.submerge_trigger = "COME FORTH,"
 
@@ -58,15 +64,26 @@ function mod:OnBossEnable()
 	self:RegisterEvent("CHAT_MSG_MONSTER_YELL")
 
 	self:Log("SPELL_CAST_SUCCESS", "Knockback", self:SpellName(20566))
+	self:Log("SPELL_CAST_START", "PullRP", self:SpellName(19774))
 
 	self:Death("Win", 11502)
 	self:Death("SonDeaths", 12143)
+	self:Death("MajordomoDeath", 12018)
+end
+
+function mod:VerifyEnable(unit, mobId)
+  if mobId == 11502 then
+    return true
+  elseif mobId == 12018 then
+    return not UnitCanAttack(unit, "player")
+  end
 end
 
 function mod:OnEngage()
 	sonsdead = 0
 	timer = nil
-	self:Bar("submerge", 180, L.submerge_bar, "spell_fire_volcano")
+	self:Bar(20566, 27, L.knockback_bar) -- guesstimate for the first wrath
+  self:Bar("submerge", 180, L.submerge_bar, "spell_fire_volcano")
 	self:Message("submerge", "yellow", nil, CL.custom_min:format(L.submerge, 3), "spell_fire_volcano")
 	self:DelayedMessage("submerge", 60, "yellow", CL.custom_min:format(L.submerge, 2))
 	self:DelayedMessage("submerge", 120, "yellow", CL.custom_min:format(L.submerge, 1))
@@ -92,11 +109,27 @@ function mod:Knockback(args)
 	self:Bar(20566, 28, L.knockback_bar)
 end
 
+function mod:PullRP()
+	self:Message("pull_rp", "white", nil, L.pull_rp_message)
+	self:Bar("pull_rp", 73, L.pull_rp_bar, L.pull_rp_icon)
+end
+
+function mod:MajordomoDeath()
+  -- it takes exactly 10 seconds for combat to start after Majodromo dies, while
+  -- the time between starting the RP/summon and killing Majordomo varies
+  local remaining = self:BarTimeLeft("pull_rp")
+  if remaining ~= 10 then
+    self:StopBar("pull_rp")
+    self:Bar("pull_rp", 10, L.pull_rp_bar, L.pull_rp_icon)
+  end
+end
+
 function mod:Emerge()
 	sonsdead = 10 -- Block this firing again if sons are killed after he emerges
 	timer = nil
-	self:Message("emerge", "yellow", "Long", L.emerge_message, "spell_fire_volcano")
+	self:Bar(20566, 27, L.knockback_bar) -- guesstimate for the first wrath after emerging
 	self:Bar("submerge", 180, L.submerge_bar, "spell_fire_volcano")
+  self:Message("emerge", "yellow", "Long", L.emerge_message, "spell_fire_volcano")
 	self:DelayedMessage("submerge", 60, "yellow", CL.custom_min:format(L.submerge, 2))
 	self:DelayedMessage("submerge", 120, "yellow", CL.custom_min:format(L.submerge, 1))
 	self:DelayedMessage("submerge", 150, "yellow", CL.custom_sec:format(L.submerge, 30))

--- a/MoltenCore/Ragnaros.lua
+++ b/MoltenCore/Ragnaros.lua
@@ -54,6 +54,7 @@ L = mod:GetLocale()
 
 function mod:GetOptions()
 	return {
+    "pull_rp",
 		"submerge",
 		"emerge",
 		20566, -- Wrath of Ragnaros

--- a/MoltenCore/Ragnaros.lua
+++ b/MoltenCore/Ragnaros.lua
@@ -111,7 +111,7 @@ function mod:Knockback(args)
 end
 
 function mod:PullRP()
-	self:Message("pull_rp", "white", nil, L.pull_rp_message)
+	self:Message("pull_rp", "cyan", nil, L.pull_rp_message)
 	self:Bar("pull_rp", 73, L.pull_rp_bar, L.pull_rp_icon)
 end
 

--- a/MoltenCore/Ragnaros.lua
+++ b/MoltenCore/Ragnaros.lua
@@ -22,11 +22,8 @@ local timer = nil
 
 local L = mod:NewLocale("enUS", true)
 if L then
-	L.pull_rp = "RP timer"
-	L.pull_rp_desc = "Timer for the RP after engaging Majordomo"
-	L.pull_rp_icon = "spell_fire_lavaspawn"
-	L.pull_rp_message = "Pull RP started, engaging in ~73s"
-	L.pull_rp_bar = "Encounter starting"
+	L.warmup_icon = "spell_fire_lavaspawn"
+	L.warmup_message = "RP started, engaging in ~73s"
 
 	L.engage_trigger = "NOW FOR YOU,"
 	L.submerge_trigger = "COME FORTH,"
@@ -54,7 +51,7 @@ L = mod:GetLocale()
 
 function mod:GetOptions()
 	return {
-    "pull_rp",
+		"warmup",
 		"submerge",
 		"emerge",
 		20566, -- Wrath of Ragnaros
@@ -65,7 +62,7 @@ function mod:OnBossEnable()
 	self:RegisterEvent("CHAT_MSG_MONSTER_YELL")
 
 	self:Log("SPELL_CAST_SUCCESS", "Knockback", self:SpellName(20566))
-	self:Log("SPELL_CAST_START", "PullRP", self:SpellName(19774))
+	self:Log("SPELL_CAST_START", "Warmup", self:SpellName(19774))
 
 	self:Death("Win", 11502)
 	self:Death("SonDeaths", 12143)
@@ -73,18 +70,18 @@ function mod:OnBossEnable()
 end
 
 function mod:VerifyEnable(unit, mobId)
-  if mobId == 11502 then
-    return true
-  elseif mobId == 12018 then
-    return not UnitCanAttack(unit, "player")
-  end
+	if mobId == 11502 then
+		return true
+	elseif mobId == 12018 then
+		return not UnitCanAttack(unit, "player")
+	end
 end
 
 function mod:OnEngage()
 	sonsdead = 0
 	timer = nil
 	self:Bar(20566, 27, L.knockback_bar) -- guesstimate for the first wrath
-  self:Bar("submerge", 180, L.submerge_bar, "spell_fire_volcano")
+	self:Bar("submerge", 180, L.submerge_bar, "spell_fire_volcano")
 	self:Message("submerge", "yellow", nil, CL.custom_min:format(L.submerge, 3), "spell_fire_volcano")
 	self:DelayedMessage("submerge", 60, "yellow", CL.custom_min:format(L.submerge, 2))
 	self:DelayedMessage("submerge", 120, "yellow", CL.custom_min:format(L.submerge, 1))
@@ -110,19 +107,19 @@ function mod:Knockback(args)
 	self:Bar(20566, 28, L.knockback_bar)
 end
 
-function mod:PullRP()
-	self:Message("pull_rp", "cyan", nil, L.pull_rp_message)
-	self:Bar("pull_rp", 73, L.pull_rp_bar, L.pull_rp_icon)
+function mod:Warmup()
+	self:Message("warmup", "cyan", nil, L.warmup_message)
+	self:Bar("warmup", 73, CL.active, L.warmup_icon)
 end
 
 function mod:MajordomoDeath()
-  -- it takes exactly 10 seconds for combat to start after Majodromo dies, while
-  -- the time between starting the RP/summon and killing Majordomo varies
-  local remaining = self:BarTimeLeft("pull_rp")
-  if remaining ~= 10 then
-    self:StopBar("pull_rp")
-    self:Bar("pull_rp", 10, L.pull_rp_bar, L.pull_rp_icon)
-  end
+	-- it takes exactly 10 seconds for combat to start after Majodromo dies, while
+	-- the time between starting the RP/summon and killing Majordomo varies
+	local remaining = self:BarTimeLeft("warmup")
+	if remaining ~= 10 then
+		self:StopBar("warmup")
+		self:Bar("warmup", 10, CL.active, L.warmup_icon)
+	end
 end
 
 function mod:Emerge()
@@ -130,7 +127,7 @@ function mod:Emerge()
 	timer = nil
 	self:Bar(20566, 27, L.knockback_bar) -- guesstimate for the first wrath after emerging
 	self:Bar("submerge", 180, L.submerge_bar, "spell_fire_volcano")
-  self:Message("emerge", "yellow", "Long", L.emerge_message, "spell_fire_volcano")
+	self:Message("emerge", "yellow", "Long", L.emerge_message, "spell_fire_volcano")
 	self:DelayedMessage("submerge", 60, "yellow", CL.custom_min:format(L.submerge, 2))
 	self:DelayedMessage("submerge", 120, "yellow", CL.custom_min:format(L.submerge, 1))
 	self:DelayedMessage("submerge", 150, "yellow", CL.custom_sec:format(L.submerge, 30))


### PR DESCRIPTION
Closes #781

This PR aims to add the RP timer when summoning Ragnaros and adds in an estimate for the first _Wrath of Ragnaros_ cast once the boss has been engaged.