### PR TITLE
MoltenCore/Shazzrah: Blink Timer

### DIFF
--- a/MoltenCore/Shazzrah.lua
+++ b/MoltenCore/Shazzrah.lua
@@ -37,7 +37,7 @@ end
 --
 
 function mod:Blink(args)
-	self:Bar(23138, 41)
+	self:CDBar(23138, 41) -- 41-50
 	self:Message(23138, "red")
 end
 

--- a/MoltenCore/Shazzrah.lua
+++ b/MoltenCore/Shazzrah.lua
@@ -29,6 +29,7 @@ end
 
 function mod:OnEngage()
 	self:Bar(19715, 10.7) -- Counterspell
+	self:Bar(23138, 30)   -- Blink
 end
 
 --------------------------------------------------------------------------------
@@ -36,7 +37,7 @@ end
 --
 
 function mod:Blink(args)
-	self:Bar(23138, 45)
+	self:Bar(23138, 41)
 	self:Message(23138, "red")
 end
 


### PR DESCRIPTION
Closes #791

DBM uses a 30s timer for the first gate, and that seems to be fairly accurate, with a certain range for error. I added a bar `OnEngage`.

```lua
function mod:OnEngage()
	self:Bar(19715, 10.7) -- Counterspell
	-- // added this line //
	self:Bar(23138, 30)   -- Blink
end
```

For any subsequent gates: time can be between 41-50s. I propose BW uses the smallest value as a baseline instead of the current 45s in order to prevent early casts. Worst case scenario, spell will fire 10s after the bar disappears. I reduced the timer to 41s accordingly.

```lua
function mod:Blink(args)
	self:Bar(23138, 41). -- changed this number to 41 instead of 45
	self:Message(23138, "red")
end
```