### PR TITLE
MoltenCore/Majordomo: Tank Teleport

### DIFF
--- a/MoltenCore/Majordomo.lua
+++ b/MoltenCore/Majordomo.lua
@@ -28,7 +28,7 @@ function mod:GetOptions()
 	return {
 		20619, -- Magic Reflection
 		21075, -- Damage Shield
-		20534, -- Teleport
+		{20534, "TANK"}, -- Teleport
 	}
 end
 

--- a/MoltenCore/Majordomo.lua
+++ b/MoltenCore/Majordomo.lua
@@ -45,7 +45,7 @@ function mod:VerifyEnable(unit)
 end
 
 function mod:OnEngage()
-	self:Bar(20534, 20)
+	self:Bar(20534, 20) -- Teleport
 end
 
 --------------------------------------------------------------------------------

--- a/MoltenCore/Majordomo.lua
+++ b/MoltenCore/Majordomo.lua
@@ -44,6 +44,10 @@ function mod:VerifyEnable(unit)
 	return (UnitIsEnemy(unit, "player") and UnitCanAttack(unit, "player")) and true or false
 end
 
+function mod:OnEngage()
+	self:Bar(20534, 20)
+end
+
 --------------------------------------------------------------------------------
 -- Event Handlers
 --
@@ -69,5 +73,5 @@ function mod:DamageShield(args)
 end
 
 function mod:Teleport(args)
-	self:Bar(20534, 25) -- 25-30
+	self:CDBar(20534, 25) -- 25-30
 end

--- a/MoltenCore/Majordomo.lua
+++ b/MoltenCore/Majordomo.lua
@@ -28,12 +28,14 @@ function mod:GetOptions()
 	return {
 		20619, -- Magic Reflection
 		21075, -- Damage Shield
+		20534, -- Teleport
 	}
 end
 
 function mod:OnBossEnable()
 	self:Log("SPELL_CAST_SUCCESS", "MagicReflection", self:SpellName(20619))
 	self:Log("SPELL_CAST_SUCCESS", "DamageShield", self:SpellName(21075))
+	self:Log("SPELL_CAST_SUCCESS", "Teleport", self:SpellName(20534))
 
 	self:RegisterEvent("CHAT_MSG_MONSTER_YELL")
 end
@@ -66,3 +68,6 @@ function mod:DamageShield(args)
 	self:DelayedMessage(21075, 25, "orange", CL.custom_sec:format(L.power_next, 5))
 end
 
+function mod:Teleport(args)
+	self:Bar(20534, 25) -- 25-30
+end


### PR DESCRIPTION
Closes #792.

This PR adds the `Teleport` skill that Majordomo casts on the Tank every 25~30 seconds. It has no message or warning sound, as it affects just the tank and requires almost no action.