### PR TITLE
Core: AI Bar

### DIFF
--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -2081,15 +2081,16 @@ do
 
 	--- Display a variable-length learning bar. Uses a CDBar internally
 	-- @param key the option key
-	-- @number phase the current phase, between 1 and 4 (or higher)
+	-- @number phase the current phase, between 1 and 4. Defaults to 4
 	-- phase = 1 indicates it's the first bar after a pull
 	-- phase = 2 or 3 indicates it's the first bar on Phase 2 or Phase 3
 	-- phase >= 4 indicates it's a regular bar and to use shortest interval in-between two regular casts.
-	-- You should use 1 inside `OnEngage` and then 2-4 on cast callbacks accordingly (usually 4)
+	-- You should use 1 inside `OnEngage` and 4 (or none) on cast callbacks.
 	-- @param[opt] text the bar text (if nil, key is used)
 	-- @param[opt] icon the bar icon (spell id or texture name)
 	function boss:AIBar(key, phase, text, icon)
 		if not self["aiBar"..key] then self["aiBar"..key] = {} end
+		if not phase then phase = 4 end
 
 		local length = 0
 		if phase >= 4 then


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR implements a variable-length, self-learning `CDBar` that adjusts itself based on the interval between casts. 
It has the following signature:
```lua
--- Display a variable-length learning bar. Uses a CDBar internally
-- @param key the option key
-- @number phase the current phase, between 1 and 4 (or higher). Defaults to 4
-- phase = 1 indicates it's the first bar after a pull
-- phase = 2 or 3 indicates it's the first bar on Phase 2 or Phase 3
-- phase >= 4 indicates it's a regular bar and to use shortest interval in-between two regular casts.
-- You should use 1 inside `OnEngage` and 4 (or none) on cast callbacks.
-- @param[opt] text the bar text (if nil, key is used)
-- @param[opt] icon the bar icon (spell id or texture name)
boss:AIBar(key, phase, text, icon)
```

Does this close any currently open issues?
------------------------------------------
No.


Any relevant logs, error output, etc?
-------------------------------------
Not really.

Any other comments?
-------------------
How is this supposed to work:
1. A call to `mod:AIBar(spellID)` is placed inside `mod:OnEngage`
2. The Addon will create a new table for this specific AI bar:
```lua
if not self["aiBar"..key] then self["aiBar"..key] = {} end
```
3. Because no previous interval exists, the Addon will branch into the following snippet:
```lua
-- No interval recorded yet, set it to GetTime(), cast as a string
self["aiBar"..key]["phase"..phase.."Interval"] = tostring(GetTime())
return -- Exit and await the first cast
```
This will create a new entry on the `aiBar<key>` table called `phase1Interval`
4. Then, the first call to `mod:AIBar(key)` will branch off into the other half of the function. 
This branch calculates the interval between the fight starting and the first cast, and saves the last cast time.
```lua
self["aiBar"..key]["phase"..i.."Interval"] = GetTime() - self["aiBar"..key]["phase"..i.."Interval"]
```
5. After this point (so, starting from the 2nd cast and onwards) the function branches off to the same first half.
This time around though, it calculates the time between the last cast and the current cast, saving the smallest value to 
```lua 
if not self["aiBar"..key].lowestSeenCast or (self["aiBar"..key].lowestSeenCast and self["aiBar"..key].lowestSeenCast > timeLastCast) then
	-- Always use lowest-seen interval for a bar
	self["aiBar"..key].lowestSeenCast = timeLastCast
	if debug then dbg(self, "AI Bar learned a new lowest interval of "..self["aiBar"..key].lowestSeenCast) end
end
```
6. After the 2nd cast, the AI Bar will create a `CDBar` with a length of `lowestSeenCast`. 
This process repeats every time `mod:AIBar(key)` is called without a `phase` argument.
7. When changing phase, simply call `mod:AIBar(key, phase)`, and swap out `phase` for 2 or 3. Then, the process starts anew for each individual phase, and a new interval will be calculated.


Where has this been tested?
---------------------------
**BigWigs Version:** v12.1-classic

**WoW Version:** 1.13.4 (11304)