### PR TITLE
CastleNathria/TheCouncilofBlood: Mythic Council of Blood Timers (Afterimages + Dance Fever)

### DIFF
--- a/CastleNathria/TheCouncilofBlood.lua
+++ b/CastleNathria/TheCouncilofBlood.lua
@@ -228,6 +228,9 @@ function mod:BossDeath(args)
 		self:StopBar(346651) -- Drain Essence
 		self:StopBar(337110) --  Dreadbolt Volley
 		self:StopBar(346657) --  Prideful Eruption
+		if self:Mythic() then
+			self:CDBar(337110, 20) -- Start the initial Afterimage Spawn
+		end
 	elseif args.mobId == 166970 then -- Stavros
 		stavrosAlive = false
 		self:StopBar(327497) -- Evasive Lunge

--- a/CastleNathria/TheCouncilofBlood.lua
+++ b/CastleNathria/TheCouncilofBlood.lua
@@ -229,7 +229,7 @@ function mod:BossDeath(args)
 		self:StopBar(337110) --  Dreadbolt Volley
 		self:StopBar(346657) --  Prideful Eruption
 		if self:Mythic() then
-			self:CDBar(337110, 20) -- Start the initial Afterimage Spawn
+			self:CDBar(337110, 20) -- Start the initial Afterimage Spawn.
 		end
 	elseif args.mobId == 166970 then -- Stavros
 		stavrosAlive = false

--- a/CastleNathria/TheCouncilofBlood.lua
+++ b/CastleNathria/TheCouncilofBlood.lua
@@ -606,15 +606,8 @@ do
 			self:PlaySound(args.spellId, "warning")
 		end
 		if #playerList == 1 then
-			self:StopBar(CL.count:format(args.spellName, dancingFeverCount))
 			dancingFeverCount = dancingFeverCount + 1
-			if dancingFeverCount < 4 then -- It's kinda messy right now, need a more consistent game
-				self:CDBar(args.spellId, dancingFeverCount == 2 and 60 or dancingFeverCount == 3 and 45, CL.count:format(args.spellName, dancingFeverCount))
-			end
-			-- "Dancing Fever-347350-npc:1 = pull:5.0[+4], 60.1[+4], Danse Macabre Begin/23.3, Baroness Frieda Killed/113.0", -- [5]
-			-- "Dancing Fever-347350-npc:1 = pull:5.0[+4], 60.1[+4], Danse Macabre Begin/14.1, 31.7/45.8[+4], Baroness Frieda Killed/62.6, Danse Macabre Begin/96.4, 31.8/128.2/190.8[+4], Castellan Niklaus Killed/81.6", -- [5]
-			-- "Dancing Fever-347350-npc:1 = pull:5.0[+4], 60.1[+4], Danse Macabre Begin/14.1, 31.7/45.8[+4], Baroness Frieda Killed/62.6, Danse Macabre Begin/96.4, 31.8/128.2/190.8[+4], Castellan Niklaus Killed/81.6", -- [5]
-			-- "Dancing Fever-347350-npc:1 = pull:5.0[+4], 60.1[+4], Danse Macabre Begin/15.4, 31.8/47.2[+4], Baroness Frieda Killed/62.5, Danse Macabre Begin/109.9, Castellan Niklaus Killed/121.1", -- [5]
+			self:CDBar(args.spellId, 60, CL.count:format(args.spellName, dancingFeverCount)) -- As of 12/22 NA Reset, Dancing fever is now applied on a consistent minute timer.
 		end
 		self:TargetsMessage(args.spellId, "orange", playerList, 5, CL.count:format(args.spellName, dancingFeverCount-1))
 	end

--- a/CastleNathria/TheCouncilofBlood.lua
+++ b/CastleNathria/TheCouncilofBlood.lua
@@ -237,7 +237,6 @@ function mod:BossDeath(args)
 		self:StopBar(331634) --  Dark Recital
 		self:StopBar(346800) --  Waltz of Blood
 		if self:Mythic() then
-			self:StopBar(337110)  --Ugly and I'm sure there is a much better way to do this, but when a boss dies it resets the Afterimage timer back to 20 seconds.
 			self:CDBar(337110, 20) -- Start the Afterimage Spawn Timer
 		end
 	elseif args.mobId == 166971 then -- Niklaus
@@ -246,7 +245,6 @@ function mod:BossDeath(args)
 		self:StopBar(346698) -- Summon Dutiful Attendant
 		self:StopBar(330978) -- Dredger Servants
 		if self:Mythic() then
-			self:StopBar(337110)  --Ugly and I'm sure there is a much better way to do this, but when a boss dies it resets the Afterimage timer back to 20 seconds.
 			self:CDBar(337110, 20) -- Start the Afterimage Spawn Timer
 		end
 	end

--- a/CastleNathria/TheCouncilofBlood.lua
+++ b/CastleNathria/TheCouncilofBlood.lua
@@ -240,8 +240,13 @@ function mod:BossDeath(args)
 		self:StopBar(330978) -- Dredger Servants
 	end
 
-	if self:Mythic() and friedaAlive == false then
-		self:CDBar(337110, 20) -- Start the initial Afterimage Spawn.
+	if self:Mythic() then
+		if friendaAlive == false then
+			self:CDBar(337110, 20) -- Start/Reset the initial Dreadbolt Volley Afterimage Spawn.
+		end
+		if stavrosAlive == false then
+			self:CDBar(331634, 40) -- Start/Reset the initial Dark Recital Afterimage Spawn
+		end
 	end
 
 	if bossesKilled == 1 then

--- a/CastleNathria/TheCouncilofBlood.lua
+++ b/CastleNathria/TheCouncilofBlood.lua
@@ -228,26 +228,22 @@ function mod:BossDeath(args)
 		self:StopBar(346651) -- Drain Essence
 		self:StopBar(337110) --  Dreadbolt Volley
 		self:StopBar(346657) --  Prideful Eruption
-		if self:Mythic() then
-			self:CDBar(337110, 20) -- Start the initial Afterimage Spawn.
-		end
 	elseif args.mobId == 166970 then -- Stavros
 		stavrosAlive = false
 		self:StopBar(327497) -- Evasive Lunge
 		self:StopBar(331634) --  Dark Recital
 		self:StopBar(346800) --  Waltz of Blood
-		if self:Mythic() then
-			self:CDBar(337110, 20) -- Start the Afterimage Spawn Timer
-		end
 	elseif args.mobId == 166971 then -- Niklaus
 		niklausAlive = false
 		self:StopBar(346690) -- Duelist's Riposte
 		self:StopBar(346698) -- Summon Dutiful Attendant
 		self:StopBar(330978) -- Dredger Servants
-		if self:Mythic() then
-			self:CDBar(337110, 20) -- Start the Afterimage Spawn Timer
-		end
 	end
+
+	if self:Mythic() and friedaAlive == false then
+		self:CDBar(337110, 20) -- Start the initial Afterimage Spawn.
+	end
+
 	if bossesKilled == 1 then
 		if friedaAlive then
 			--self:CDBar(346651, 15) -- Drain Essence

--- a/CastleNathria/TheCouncilofBlood.lua
+++ b/CastleNathria/TheCouncilofBlood.lua
@@ -241,7 +241,7 @@ function mod:BossDeath(args)
 	end
 
 	if self:Mythic() then
-		if friendaAlive == false then
+		if friedaAlive == false then
 			self:CDBar(337110, 20) -- Start/Reset the initial Dreadbolt Volley Afterimage Spawn.
 		end
 		if stavrosAlive == false then

--- a/CastleNathria/TheCouncilofBlood.lua
+++ b/CastleNathria/TheCouncilofBlood.lua
@@ -236,11 +236,19 @@ function mod:BossDeath(args)
 		self:StopBar(327497) -- Evasive Lunge
 		self:StopBar(331634) --  Dark Recital
 		self:StopBar(346800) --  Waltz of Blood
+		if self:Mythic() then
+			self:StopBar(337110)  --Ugly and I'm sure there is a much better way to do this, but when a boss dies it resets the Afterimage timer back to 20 seconds.
+			self:CDBar(337110, 20) -- Start the Afterimage Spawn Timer
+		end
 	elseif args.mobId == 166971 then -- Niklaus
 		niklausAlive = false
 		self:StopBar(346690) -- Duelist's Riposte
 		self:StopBar(346698) -- Summon Dutiful Attendant
 		self:StopBar(330978) -- Dredger Servants
+		if self:Mythic() then
+			self:StopBar(337110)  --Ugly and I'm sure there is a much better way to do this, but when a boss dies it resets the Afterimage timer back to 20 seconds.
+			self:CDBar(337110, 20) -- Start the Afterimage Spawn Timer
+		end
 	end
 	if bossesKilled == 1 then
 		if friedaAlive then


### PR DESCRIPTION
Add timers for Baroness and Stavros afterimages.
Needs further testing, but Baroness afterimage timer resets to 20 seconds on new boss death event, can only assume the same for Stavros afterimage.

Updated to have accurate timers for dance fever after hotfix made it actually work.