### PR TITLE
Increased max emphasizeTime to 30

### DIFF
--- a/Plugins/Bars.lua
+++ b/Plugins/Bars.lua
@@ -1085,7 +1085,7 @@ do
 						name = L.emphasizeAt,
 						order = 6,
 						min = 6,
-						max = 20,
+						max = 30,
 						step = 1,
 					},
 					fontSizeEmph = {


### PR DESCRIPTION
So currently the maximum emphasize time has a hard limit of 20 secs. I play disc priest and with Spirit Shell my ramps usually take ~23 seconds, so I'd like to see my emphasized timers earlier. People on the disc priest discord seem to share this sentiment. So I suggest increasing the hard limit to maybe 30 seconds.