### PR TITLE
Plugins/Countdown: Update default voice options

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -156,6 +156,7 @@ globals = {
 	"GetAddOnMetadata",
 	"GetAddOnOptionalDependencies",
 	"GetBuildInfo",
+	"GetCurrentRegion",
 	"GetDifficultyInfo",
 	"GetFramesRegisteredForEvent",
 	"GetInstanceInfo",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -156,7 +156,7 @@ globals = {
 	"GetAddOnMetadata",
 	"GetAddOnOptionalDependencies",
 	"GetBuildInfo",
-	"GetCurrentRegion",
+	"GetCurrentRegion", -- XXX temp 9.0.5
 	"GetDifficultyInfo",
 	"GetFramesRegisteredForEvent",
 	"GetInstanceInfo",

--- a/Plugins/Countdown.lua
+++ b/Plugins/Countdown.lua
@@ -127,11 +127,12 @@ for locale, info in next, voiceMap do
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\5.ogg",
 	})
 
+	local id = ("%s: Default (Female)"):format(locale)
 	if locale == "esMX" then
 		-- never extracted the esMX female announcer and it's gone now, so just use esES
 		locale = "esES"
 	end
-	BigWigsAPI:RegisterCountdown(("%s: Default (Female)"):format(locale), name:format(female), {
+	BigWigsAPI:RegisterCountdown(id, name:format(female), {
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\1.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\2.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\3.ogg",

--- a/Plugins/Countdown.lua
+++ b/Plugins/Countdown.lua
@@ -100,6 +100,21 @@ BigWigsAPI:RegisterCountdown("English: Jim", {
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Jim\\10.ogg",
 })
 
+BigWigsAPI:RegisterCountdown("English: Default (Male)", {
+	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\male\\1.ogg",
+	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\male\\2.ogg",
+	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\male\\3.ogg",
+	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\male\\4.ogg",
+	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\male\\5.ogg",
+})
+BigWigsAPI:RegisterCountdown("English: Default (Female)", {
+	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\1.ogg",
+	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\2.ogg",
+	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\3.ogg",
+	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\4.ogg",
+	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\5.ogg",
+})
+
 for locale, name in next, voiceMap do
 	BigWigsAPI:RegisterCountdown(("%s (%s)"):format(name, _G.MALE), {
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\1.ogg",
@@ -109,7 +124,7 @@ for locale, name in next, voiceMap do
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\5.ogg",
 	})
 	if locale == "esMX" then
-		-- never extracted the esMX female announcer voice and it's gone now, so just use esES
+		-- never extracted the esMX female announcer and it's gone now, so just use esES
 		locale = "esES"
 	end
 	BigWigsAPI:RegisterCountdown(("%s (%s)"):format(name, _G.FEMALE), {

--- a/Plugins/Countdown.lua
+++ b/Plugins/Countdown.lua
@@ -11,6 +11,7 @@ local plugin = BigWigs:NewPlugin("Countdown")
 if not plugin then return end
 
 local voiceMap = {
+	enUS = {"English: Default (%s)", "Male", "Female"},
 	deDE = {"Deutsch: Standard (%s)", "Männlich", "Weiblich"},
 	esES = {"Español (es): Predeterminado (%s)", "Masculino", "Femenino"},
 	esMX = {"Español (mx): Predeterminado (%s)", "Masculino", "Femenino"},
@@ -25,7 +26,7 @@ local voiceMap = {
 local defaultVoice = "English: Amy"
 do
 	local locale = GetLocale()
-	if voiceMap[locale] then
+	if locale ~= "enUS" and voiceMap[locale] then
 		defaultVoice = ("%s: Default (Female)"):format(locale)
 	end
 end
@@ -99,21 +100,6 @@ BigWigsAPI:RegisterCountdown("English: Jim", {
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Jim\\8.ogg",
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Jim\\9.ogg",
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Jim\\10.ogg",
-})
-
-BigWigsAPI:RegisterCountdown("enUS: Default (Male)", "English: Default (Male)", {
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\male\\1.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\male\\2.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\male\\3.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\male\\4.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\male\\5.ogg",
-})
-BigWigsAPI:RegisterCountdown("enUS: Default (Female)", "English: Default (Female)", {
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\1.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\2.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\3.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\4.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\5.ogg",
 })
 
 for locale, info in next, voiceMap do

--- a/Plugins/Countdown.lua
+++ b/Plugins/Countdown.lua
@@ -11,17 +11,23 @@ local plugin = BigWigs:NewPlugin("Countdown")
 if not plugin then return end
 
 local voiceMap = {
-	deDE = "Deutsch: Heroes of the Storm",
-	esES = "Español: Heroes of the Storm",
-	esMX = "Español: Heroes of the Storm",
-	frFR = "Français: Heroes of the Storm",
-	ruRU = "Русский: Heroes of the Storm",
-	koKR = "한국어: Heroes of the Storm",
-	itIT = "Italiano: Heroes of the Storm",
-	ptBR = "Português: Heroes of the Storm",
-	zhCN = "简体中文: Heroes of the Storm",
-	zhTW = "繁體中文: Heroes of the Storm",
+	deDE = "Deutsch: Default",
+	esES = "Español (es): Default",
+	esMX = "Español (mx): Default",
+	frFR = "Français: Default",
+	ruRU = "Русский: Default",
+	koKR = "한국어: Default",
+	itIT = "Italiano: Default",
+	ptBR = "Português: Default",
+	zhCN = "简体中文: Default",
+	zhTW = "繁體中文: Default",
 }
+local defaultVoice = voiceMap[GetLocale()]
+if defaultVoice then
+	defaultVoice = ("%s (%s)"):format(defaultVoice, FEMALE)
+else
+	defaultVoice = "English: Amy"
+end
 
 plugin.defaultDB = {
 	textEnabled = true,
@@ -30,7 +36,7 @@ plugin.defaultDB = {
 	fontSize = 48,
 	monochrome = false,
 	fontColor = { r = 1, g = 0, b = 0 },
-	voice = voiceMap[GetLocale()] or "English: Amy",
+	voice = defaultVoice,
 	countdownTime = 5,
 	position = {"TOP", "TOP", 0, -300},
 	bossCountdowns = {},
@@ -93,76 +99,27 @@ BigWigsAPI:RegisterCountdown("English: Jim", {
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Jim\\9.ogg",
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Jim\\10.ogg",
 })
-BigWigsAPI:RegisterCountdown("English: Heroes of the Storm", {
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\1.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\2.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\3.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\4.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\5.ogg",
-})
-BigWigsAPI:RegisterCountdown("Deutsch: Heroes of the Storm", {
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\deDE\\female\\1.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\deDE\\female\\2.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\deDE\\female\\3.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\deDE\\female\\4.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\deDE\\female\\5.ogg",
-})
-BigWigsAPI:RegisterCountdown("Español: Heroes of the Storm", {
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\esES\\female\\1.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\esES\\female\\2.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\esES\\female\\3.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\esES\\female\\4.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\esES\\female\\5.ogg",
-})
-BigWigsAPI:RegisterCountdown("Français: Heroes of the Storm", {
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\frFR\\female\\1.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\frFR\\female\\2.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\frFR\\female\\3.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\frFR\\female\\4.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\frFR\\female\\5.ogg",
-})
-BigWigsAPI:RegisterCountdown("Русский: Heroes of the Storm", {
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\ruRU\\female\\1.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\ruRU\\female\\2.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\ruRU\\female\\3.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\ruRU\\female\\4.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\ruRU\\female\\5.ogg",
-})
-BigWigsAPI:RegisterCountdown("한국어: Heroes of the Storm", {
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\koKR\\female\\1.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\koKR\\female\\2.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\koKR\\female\\3.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\koKR\\female\\4.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\koKR\\female\\5.ogg",
-})
-BigWigsAPI:RegisterCountdown("Italiano: Heroes of the Storm", {
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\itIT\\female\\1.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\itIT\\female\\2.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\itIT\\female\\3.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\itIT\\female\\4.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\itIT\\female\\5.ogg",
-})
-BigWigsAPI:RegisterCountdown("Português: Heroes of the Storm", {
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\ptBR\\female\\1.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\ptBR\\female\\2.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\ptBR\\female\\3.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\ptBR\\female\\4.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\ptBR\\female\\5.ogg",
-})
-BigWigsAPI:RegisterCountdown("简体中文: Heroes of the Storm", {
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\zhCN\\female\\1.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\zhCN\\female\\2.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\zhCN\\female\\3.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\zhCN\\female\\4.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\zhCN\\female\\5.ogg",
-})
-BigWigsAPI:RegisterCountdown("繁體中文: Heroes of the Storm", {
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\zhTW\\female\\1.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\zhTW\\female\\2.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\zhTW\\female\\3.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\zhTW\\female\\4.ogg",
-	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\zhTW\\female\\5.ogg",
-})
+
+for locale, name in next, voiceMap do
+	BigWigsAPI:RegisterCountdown(("%s (%s)"):format(name, _G.MALE), {
+		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\1.ogg",
+		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\2.ogg",
+		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\3.ogg",
+		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\4.ogg",
+		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\5.ogg",
+	})
+	if locale == "esMX" then
+		-- never extracted the esMX female announcer voice and it's gone now, so just use esES
+		locale = "esES"
+	end
+	BigWigsAPI:RegisterCountdown(("%s (%s)"):format(name, _G.FEMALE), {
+		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\1.ogg",
+		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\2.ogg",
+		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\3.ogg",
+		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\4.ogg",
+		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\5.ogg",
+	})
+end
 
 --------------------------------------------------------------------------------
 -- Anchors & Frames
@@ -529,7 +486,7 @@ do
 
 		-- Reset invalid voice selections
 		if not BigWigsAPI:HasCountdown(db.voice) then
-			db.voice = voiceMap[GetLocale()] or "English: Amy"
+			db.voice = defaultVoice or "English: Amy"
 		end
 		for boss, tbl in next, db.bossCountdowns do
 			for ability, chosenVoice in next, tbl do

--- a/Plugins/Countdown.lua
+++ b/Plugins/Countdown.lua
@@ -101,14 +101,14 @@ BigWigsAPI:RegisterCountdown("English: Jim", {
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Jim\\10.ogg",
 })
 
-BigWigsAPI:RegisterCountdown("English: Default (Male)", {
+BigWigsAPI:RegisterCountdown("enUS: Default (Male)", "English: Default (Male)", {
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\male\\1.ogg",
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\male\\2.ogg",
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\male\\3.ogg",
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\male\\4.ogg",
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\male\\5.ogg",
 })
-BigWigsAPI:RegisterCountdown("English: Default (Female)", {
+BigWigsAPI:RegisterCountdown("enUS: Default (Female)", "English: Default (Female)", {
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\1.ogg",
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\2.ogg",
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\3.ogg",

--- a/Plugins/Countdown.lua
+++ b/Plugins/Countdown.lua
@@ -11,20 +11,20 @@ local plugin = BigWigs:NewPlugin("Countdown")
 if not plugin then return end
 
 local voiceMap = {
-	deDE = {"Deutsch","Standard","Männlich","Weiblich"},
-	esES = {"Español (es)","Predeterminado","Masculino","Femenino"},
-	esMX = {"Español (mx)","Predeterminado","Masculino","Femenino"},
-	frFR = {"Français","Défaut","Homme","Femme"},
-	itIT = {"Italiano","Predefinito","Maschio","Femmina"},
-	koKR = {"한국어","기본","남성","여성"},
-	ptBR = {"Português","Padrão","Masculino","Feminino"},
-	ruRU = {"Русский","По умолчанию","Мужской","Женский"},
-	zhCN = {"简体中文","默认","男性","女性"},
-	zhTW = {"繁體中文","預設值","男性","女性"},
+	deDE = {"Deutsch", "Standard", "Männlich", "Weiblich", "%s: %s (%s)"},
+	esES = {"Español (es)", "Predeterminado", "Masculino", "Femenino", "%s: %s (%s)"},
+	esMX = {"Español (mx)", "Predeterminado", "Masculino", "Femenino", "%s: %s (%s)"},
+	frFR = {"Français", "Défaut", "Homme", "Femme", "%s : %s (%s)"},
+	itIT = {"Italiano", "Predefinito", "Maschio", "Femmina", "%s: %s (%s)"},
+	koKR = {"한국어", "기본", "남성", "여성", "%s : %s (%s)"},
+	ptBR = {"Português", "Padrão", "Masculino", "Feminino", "%s: %s (%s)"},
+	ruRU = {"Русский", "По умолчанию", "Мужской", "Женский", "%s: %s (%s)"},
+	zhCN = {"简体中文", "默认", "男性", "女性", "%s:%s(%s)"},
+	zhTW = {"繁體中文", "預設值", "男性", "女性", "%s:%s(%s)"},
 }
 local defaultVoice = voiceMap[GetLocale()]
 if defaultVoice then
-	defaultVoice = ("%s: %s (%s)"):format(defaultVoice[1], defaultVoice[2], defaultVoice[4])
+	defaultVoice = defaultVoice[5]:format(defaultVoice[1], defaultVoice[2], defaultVoice[4])
 else
 	defaultVoice = "English: Amy"
 end
@@ -116,7 +116,7 @@ BigWigsAPI:RegisterCountdown("English: Default (Female)", {
 })
 
 for locale, info in next, voiceMap do
-	BigWigsAPI:RegisterCountdown(("%s: %s (%s)"):format(info[1], info[2], info[3]), {
+	BigWigsAPI:RegisterCountdown(info[5]:format(info[1], info[2], info[3]), {
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\1.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\2.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\3.ogg",
@@ -127,7 +127,7 @@ for locale, info in next, voiceMap do
 		-- never extracted the esMX female announcer and it's gone now, so just use esES
 		locale = "esES"
 	end
-	BigWigsAPI:RegisterCountdown(("%s: %s (%s)"):format(info[1], info[2], info[4]), {
+	BigWigsAPI:RegisterCountdown(info[5]:format(info[1], info[2], info[4]), {
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\1.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\2.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\3.ogg",

--- a/Plugins/Countdown.lua
+++ b/Plugins/Countdown.lua
@@ -486,7 +486,7 @@ do
 
 		-- Reset invalid voice selections
 		if not BigWigsAPI:HasCountdown(db.voice) then
-			db.voice = defaultVoice or "English: Amy"
+			db.voice = defaultVoice
 		end
 		for boss, tbl in next, db.bossCountdowns do
 			for ability, chosenVoice in next, tbl do

--- a/Plugins/Countdown.lua
+++ b/Plugins/Countdown.lua
@@ -126,12 +126,13 @@ for locale, info in next, voiceMap do
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\4.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\5.ogg",
 	})
+
+	id = ("%s: Default (Female)"):format(locale)
+	name = info[5]:format(info[1], info[2], info[4])
 	if locale == "esMX" then
 		-- never extracted the esMX female announcer and it's gone now, so just use esES
 		locale = "esES"
 	end
-	id = ("%s: Default (Female)"):format(locale)
-	name = info[5]:format(info[1], info[2], info[4])
 	BigWigsAPI:RegisterCountdown(id, name, {
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\1.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\2.ogg",

--- a/Plugins/Countdown.lua
+++ b/Plugins/Countdown.lua
@@ -11,16 +11,16 @@ local plugin = BigWigs:NewPlugin("Countdown")
 if not plugin then return end
 
 local voiceMap = {
-	deDE = {"Deutsch", "Standard", "Männlich", "Weiblich", "%s: %s (%s)"},
-	esES = {"Español (es)", "Predeterminado", "Masculino", "Femenino", "%s: %s (%s)"},
-	esMX = {"Español (mx)", "Predeterminado", "Masculino", "Femenino", "%s: %s (%s)"},
-	frFR = {"Français", "Défaut", "Homme", "Femme", "%s : %s (%s)"},
-	itIT = {"Italiano", "Predefinito", "Maschio", "Femmina", "%s: %s (%s)"},
-	koKR = {"한국어", "기본", "남성", "여성", "%s : %s (%s)"},
-	ptBR = {"Português", "Padrão", "Masculino", "Feminino", "%s: %s (%s)"},
-	ruRU = {"Русский", "По умолчанию", "Мужской", "Женский", "%s: %s (%s)"},
-	zhCN = {"简体中文", "默认", "男性", "女性", "%s:%s(%s)"},
-	zhTW = {"繁體中文", "預設值", "男性", "女性", "%s:%s(%s)"},
+	deDE = {"Deutsch: Standard (%s)", "Männlich", "Weiblich"},
+	esES = {"Español (es): Predeterminado (%s)", "Masculino", "Femenino"},
+	esMX = {"Español (mx): Predeterminado (%s)", "Masculino", "Femenino"},
+	frFR = {"Français : Défaut (%s)", "Homme", "Femme"},
+	itIT = {"Italiano: Predefinito (%s)", "Maschio", "Femmina"},
+	koKR = {"한국어 : 기본 (%s)", "남성", "여성"},
+	ptBR = {"Português: Padrão (%s)", "Masculino", "Feminino"},
+	ruRU = {"Русский: По умолчанию (%s)", "Мужской", "Женский"},
+	zhCN = {"简体中文:默认(%s)", "男性", "女性"},
+	zhTW = {"繁體中文:預設值(%s)", "男性", "女性"},
 }
 local defaultVoice = "English: Amy"
 do
@@ -117,9 +117,9 @@ BigWigsAPI:RegisterCountdown("English: Default (Female)", {
 })
 
 for locale, info in next, voiceMap do
-	local id = ("%s: Default (Male)"):format(locale)
-	local name = info[5]:format(info[1], info[2], info[3])
-	BigWigsAPI:RegisterCountdown(id, name, {
+	local name, male, female = unpack(info)
+
+	BigWigsAPI:RegisterCountdown(("%s: Default (Male)"):format(locale), name:format(male), {
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\1.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\2.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\3.ogg",
@@ -127,13 +127,11 @@ for locale, info in next, voiceMap do
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\5.ogg",
 	})
 
-	id = ("%s: Default (Female)"):format(locale)
-	name = info[5]:format(info[1], info[2], info[4])
 	if locale == "esMX" then
 		-- never extracted the esMX female announcer and it's gone now, so just use esES
 		locale = "esES"
 	end
-	BigWigsAPI:RegisterCountdown(id, name, {
+	BigWigsAPI:RegisterCountdown(("%s: Default (Female)"):format(locale), name:format(female), {
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\1.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\2.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\3.ogg",

--- a/Plugins/Countdown.lua
+++ b/Plugins/Countdown.lua
@@ -11,20 +11,20 @@ local plugin = BigWigs:NewPlugin("Countdown")
 if not plugin then return end
 
 local voiceMap = {
-	deDE = "Deutsch: Default",
-	esES = "Español (es): Default",
-	esMX = "Español (mx): Default",
-	frFR = "Français: Default",
-	ruRU = "Русский: Default",
-	koKR = "한국어: Default",
-	itIT = "Italiano: Default",
-	ptBR = "Português: Default",
-	zhCN = "简体中文: Default",
-	zhTW = "繁體中文: Default",
+	deDE = {"Deutsch","Standard","Männlich","Weiblich"},
+	esES = {"Español (es)","Predeterminado","Masculino","Femenino"},
+	esMX = {"Español (mx)","Predeterminado","Masculino","Femenino"},
+	frFR = {"Français","Défaut","Homme","Femme"},
+	itIT = {"Italiano","Predefinito","Maschio","Femmina"},
+	koKR = {"한국어","기본","남성","여성"},
+	ptBR = {"Português","Padrão","Masculino","Feminino"},
+	ruRU = {"Русский","По умолчанию","Мужской","Женский"},
+	zhCN = {"简体中文","默认","男性","女性"},
+	zhTW = {"繁體中文","預設值","男性","女性"},
 }
 local defaultVoice = voiceMap[GetLocale()]
 if defaultVoice then
-	defaultVoice = ("%s (%s)"):format(defaultVoice, _G.FEMALE)
+	defaultVoice = ("%s: %s (%s)"):format(defaultVoice[1], defaultVoice[2], defaultVoice[4])
 else
 	defaultVoice = "English: Amy"
 end
@@ -115,8 +115,8 @@ BigWigsAPI:RegisterCountdown("English: Default (Female)", {
 	"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\enUS\\female\\5.ogg",
 })
 
-for locale, name in next, voiceMap do
-	BigWigsAPI:RegisterCountdown(("%s (%s)"):format(name, _G.MALE), {
+for locale, info in next, voiceMap do
+	BigWigsAPI:RegisterCountdown(("%s: %s (%s)"):format(info[1], info[2], info[3]), {
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\1.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\2.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\3.ogg",
@@ -127,7 +127,7 @@ for locale, name in next, voiceMap do
 		-- never extracted the esMX female announcer and it's gone now, so just use esES
 		locale = "esES"
 	end
-	BigWigsAPI:RegisterCountdown(("%s (%s)"):format(name, _G.FEMALE), {
+	BigWigsAPI:RegisterCountdown(("%s: %s (%s)"):format(info[1], info[2], info[4]), {
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\1.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\2.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\3.ogg",

--- a/Plugins/Countdown.lua
+++ b/Plugins/Countdown.lua
@@ -24,7 +24,7 @@ local voiceMap = {
 }
 local defaultVoice = voiceMap[GetLocale()]
 if defaultVoice then
-	defaultVoice = ("%s (%s)"):format(defaultVoice, FEMALE)
+	defaultVoice = ("%s (%s)"):format(defaultVoice, _G.FEMALE)
 else
 	defaultVoice = "English: Amy"
 end

--- a/Plugins/Countdown.lua
+++ b/Plugins/Countdown.lua
@@ -22,11 +22,12 @@ local voiceMap = {
 	zhCN = {"简体中文", "默认", "男性", "女性", "%s:%s(%s)"},
 	zhTW = {"繁體中文", "預設值", "男性", "女性", "%s:%s(%s)"},
 }
-local defaultVoice = voiceMap[GetLocale()]
-if defaultVoice then
-	defaultVoice = defaultVoice[5]:format(defaultVoice[1], defaultVoice[2], defaultVoice[4])
-else
-	defaultVoice = "English: Amy"
+local defaultVoice = "English: Amy"
+do
+	local locale = GetLocale()
+	if voiceMap[locale] then
+		defaultVoice = ("%s: Default (Female)"):format(locale)
+	end
 end
 
 plugin.defaultDB = {
@@ -116,7 +117,9 @@ BigWigsAPI:RegisterCountdown("English: Default (Female)", {
 })
 
 for locale, info in next, voiceMap do
-	BigWigsAPI:RegisterCountdown(info[5]:format(info[1], info[2], info[3]), {
+	local id = ("%s: Default (Male)"):format(locale)
+	local name = info[5]:format(info[1], info[2], info[3])
+	BigWigsAPI:RegisterCountdown(id, name, {
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\1.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\2.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\male\\3.ogg",
@@ -127,7 +130,9 @@ for locale, info in next, voiceMap do
 		-- never extracted the esMX female announcer and it's gone now, so just use esES
 		locale = "esES"
 	end
-	BigWigsAPI:RegisterCountdown(info[5]:format(info[1], info[2], info[4]), {
+	id = ("%s: Default (Female)"):format(locale)
+	name = info[5]:format(info[1], info[2], info[4])
+	BigWigsAPI:RegisterCountdown(id, name, {
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\1.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\2.ogg",
 		"Interface\\AddOns\\BigWigs\\Media\\Sounds\\Heroes\\"..locale.."\\female\\3.ogg",


### PR DESCRIPTION
Replaces the "Heroes of the Storm" text with just "Default". Maybe use "Blizzard"? I dunno, HoTS is long and doesn't really matter.