### PR TITLE
Suffering sound update.

### DIFF
--- a/SanctumOfDomination/RemnantOfNerzhul.lua
+++ b/SanctumOfDomination/RemnantOfNerzhul.lua
@@ -180,7 +180,10 @@ do
 			self:PlaySound(349890, "warning")
 			self:Say(349890, CL.beam)
 			self:SayCountdown(349890, 3, nil, 2)
+		else			
+			self:PlaySound(349890, "alert")
 		end
+				
 		self:TargetMessage(349890, "purple", name, CL.beam)
 	end
 


### PR DESCRIPTION
Add sound for non-tanks on Suffering to alert dps and healers to be aware of tank/boss positioning.