### PR TITLE
Hyjal/Trash: Update widget IDs for BCC

### DIFF
--- a/BurningCrusade/Hyjal/Trash.lua
+++ b/BurningCrusade/Hyjal/Trash.lua
@@ -82,8 +82,11 @@ function mod:OnBossEnable()
 	self:RegisterMessage("BigWigs_OnBossWin")
 
 	self:RegisterEvent("GOSSIP_SHOW")
-	self:RegisterWidgetEvent(500, "UpdateEnemies")
-	self:RegisterWidgetEvent(528, "UpdateWaves")
+--	self:RegisterWidgetEvent(500, "UpdateEnemies")
+	self:RegisterWidgetEvent(3093, "UpdateEnemies")
+	
+--	self:RegisterWidgetEvent(528, "UpdateWaves")
+	self:RegisterWidgetEvent(3121, "UpdateWaves")
 	self:RegisterMessage("BigWigs_BossComm")
 end
 


### PR DESCRIPTION
After testing Mount Hyjal on bcc ptr i found out that widgetid that bigwigs uses to track trash waves is different on bcc ptr compared to classic. 
Changing source files to reflect changes made to ptr.