### PR TITLE
SepulcherOfTheFirstOnes: Locale fix

### DIFF
--- a/SepulcherOfTheFirstOnes/Locales/deDE.lua
+++ b/SepulcherOfTheFirstOnes/Locales/deDE.lua
@@ -147,7 +147,9 @@ if L then
 	L.mythic_blood_soak_stage_1 = "Phase 1 Blut-Soak Timer"
 	L.mythic_blood_soak_stage_1_desc = "Zeigt eine Leiste mit guten Zeitpunkten zum Heilen von Azeroth an, genutzt von Echo beim ersten Kill"
 	L.mythic_blood_soak_stage_2 = "Phase 2 Blut-Soak Timer"
+	L.mythic_blood_soak_stage_2_desc = L.mythic_blood_soak_stage_1_desc
 	L.mythic_blood_soak_stage_3 = "Phase 3 Blut-Soak Timer"
+	L.mythic_blood_soak_stage_3_desc = L.mythic_blood_soak_stage_1_desc
 
 	L.mythic_blood_soak_bar = "Azeroth heilen"
 

--- a/SepulcherOfTheFirstOnes/Locales/esES.lua
+++ b/SepulcherOfTheFirstOnes/Locales/esES.lua
@@ -145,9 +145,11 @@ if L then
 	-- L.azeroth_new_health_minus = "Azeroth Health: -%.1f%%  (%d)"
 
 	-- L.mythic_blood_soak_stage_1 = "Stage 1 Blood Soak timings"
-	-- L.mythic_blood_soak_stage_2 = "Stage 2 Blood Soak timings"
-	-- L.mythic_blood_soak_stage_3 = "Stage 3 Blood Soak timings"
 	-- L.mythic_blood_soak_stage_1_desc = "Show a bar for timings when healing azeroth is at a good time, used by Echo on their first kill"
+	-- L.mythic_blood_soak_stage_2 = "Stage 2 Blood Soak timings"
+	-- L.mythic_blood_soak_stage_2_desc = L.mythic_blood_soak_stage_1_desc
+	-- L.mythic_blood_soak_stage_3 = "Stage 3 Blood Soak timings"
+	-- L.mythic_blood_soak_stage_3_desc = L.mythic_blood_soak_stage_1_desc
 	-- L.mythic_blood_soak_bar = "Heal Azeroth"
 
 	-- L.floors_open = "Floors Open"

--- a/SepulcherOfTheFirstOnes/Locales/esMX.lua
+++ b/SepulcherOfTheFirstOnes/Locales/esMX.lua
@@ -145,9 +145,11 @@ if L then
 	-- L.azeroth_new_health_minus = "Azeroth Health: -%.1f%%  (%d)"
 
 	-- L.mythic_blood_soak_stage_1 = "Stage 1 Blood Soak timings"
-	-- L.mythic_blood_soak_stage_2 = "Stage 2 Blood Soak timings"
-	-- L.mythic_blood_soak_stage_3 = "Stage 3 Blood Soak timings"
 	-- L.mythic_blood_soak_stage_1_desc = "Show a bar for timings when healing azeroth is at a good time, used by Echo on their first kill"
+	-- L.mythic_blood_soak_stage_2 = "Stage 2 Blood Soak timings"
+	-- L.mythic_blood_soak_stage_2_desc = L.mythic_blood_soak_stage_1_desc
+	-- L.mythic_blood_soak_stage_3 = "Stage 3 Blood Soak timings"
+	-- L.mythic_blood_soak_stage_3_desc = L.mythic_blood_soak_stage_1_desc
 	-- L.mythic_blood_soak_bar = "Heal Azeroth"
 
 	-- L.floors_open = "Floors Open"

--- a/SepulcherOfTheFirstOnes/Locales/frFR.lua
+++ b/SepulcherOfTheFirstOnes/Locales/frFR.lua
@@ -145,9 +145,11 @@ if L then
 	-- L.azeroth_new_health_minus = "Azeroth Health: -%.1f%%  (%d)"
 
 	-- L.mythic_blood_soak_stage_1 = "Stage 1 Blood Soak timings"
-	-- L.mythic_blood_soak_stage_2 = "Stage 2 Blood Soak timings"
-	-- L.mythic_blood_soak_stage_3 = "Stage 3 Blood Soak timings"
 	-- L.mythic_blood_soak_stage_1_desc = "Show a bar for timings when healing azeroth is at a good time, used by Echo on their first kill"
+	-- L.mythic_blood_soak_stage_2 = "Stage 2 Blood Soak timings"
+	-- L.mythic_blood_soak_stage_2_desc = L.mythic_blood_soak_stage_1_desc
+	-- L.mythic_blood_soak_stage_3 = "Stage 3 Blood Soak timings"
+	-- L.mythic_blood_soak_stage_3_desc = L.mythic_blood_soak_stage_1_desc
 	-- L.mythic_blood_soak_bar = "Heal Azeroth"
 
 	-- L.floors_open = "Floors Open"

--- a/SepulcherOfTheFirstOnes/Locales/itIT.lua
+++ b/SepulcherOfTheFirstOnes/Locales/itIT.lua
@@ -145,9 +145,11 @@ if L then
 	L.azeroth_new_health_minus = "Salute di Azeroth: -%.1f%%  (%d)"
 
 	L.mythic_blood_soak_stage_1 = "Timing per gli assorbimenti del Sangue in Fase 1"
-	L.mythic_blood_soak_stage_2 = "Timing per gli assorbimenti del Sangue in Fase 2"
-	L.mythic_blood_soak_stage_3 = "Timing per gli assorbimenti del Sangue in Fase 3"
 	L.mythic_blood_soak_stage_1_desc = "Mostra una barra per illustrare quale è il timing migliore per curare Azeroth, usata dall'Eco dopo la prima uccisione"
+	L.mythic_blood_soak_stage_2 = "Timing per gli assorbimenti del Sangue in Fase 2"
+	L.mythic_blood_soak_stage_2_desc = L.mythic_blood_soak_stage_1_desc
+	L.mythic_blood_soak_stage_3 = "Timing per gli assorbimenti del Sangue in Fase 3"
+	L.mythic_blood_soak_stage_3_desc = L.mythic_blood_soak_stage_1_desc
 	L.mythic_blood_soak_bar = "Cura Azeroth"
 
 	L.floors_open = "Pavimento Aperto"

--- a/SepulcherOfTheFirstOnes/Locales/koKR.lua
+++ b/SepulcherOfTheFirstOnes/Locales/koKR.lua
@@ -145,9 +145,11 @@ if L then
 	L.azeroth_new_health_minus = "아제로스 체력: -%.1f%%  (%d)"
 
 	L.mythic_blood_soak_stage_1 = "1페이즈 피 흡수 타이밍"
-	L.mythic_blood_soak_stage_2 = "2페이즈 피 흡수 타이밍"
-	L.mythic_blood_soak_stage_3 = "3페이즈 피 흡수 타이밍"
 	L.mythic_blood_soak_stage_1_desc = "아제로스를 힐할수 있는 좋은 타이밍이 언제인지 보이기. 에코가 첫킬 당시 사용."
+	L.mythic_blood_soak_stage_2 = "2페이즈 피 흡수 타이밍"
+	L.mythic_blood_soak_stage_2_desc = L.mythic_blood_soak_stage_1_desc
+	L.mythic_blood_soak_stage_3 = "3페이즈 피 흡수 타이밍"
+	L.mythic_blood_soak_stage_3_desc = L.mythic_blood_soak_stage_1_desc
 	L.mythic_blood_soak_bar = "아제로스 힐"
 
 	L.floors_open = "바닥 열림"

--- a/SepulcherOfTheFirstOnes/Locales/ptBR.lua
+++ b/SepulcherOfTheFirstOnes/Locales/ptBR.lua
@@ -145,9 +145,11 @@ if L then
 	L.azeroth_new_health_minus = "Saúde de Azeroth: -%.1f%%  (%d)"
 
 	L.mythic_blood_soak_stage_1 = "Estágio 1, Temporizadores para soaks de sangue"
-	L.mythic_blood_soak_stage_2 = "Estágio 2, Temporizadores para soaks de sangue"
-	L.mythic_blood_soak_stage_3 = "Estágio 3, Temporizadores para soaks de sangue"
 	L.mythic_blood_soak_stage_1_desc = "Mostra uma barra com temporizadores quando está em um bom momento para curar azeroth, usado pela Echo em sua primeira morte"
+	L.mythic_blood_soak_stage_2 = "Estágio 2, Temporizadores para soaks de sangue"
+	L.mythic_blood_soak_stage_2_desc = L.mythic_blood_soak_stage_1_desc
+	L.mythic_blood_soak_stage_3 = "Estágio 3, Temporizadores para soaks de sangue"
+	L.mythic_blood_soak_stage_3_desc = L.mythic_blood_soak_stage_1_desc
 	L.mythic_blood_soak_bar = "Cure Azeroth"
 
 	L.floors_open = "Abertura de chão"

--- a/SepulcherOfTheFirstOnes/Locales/zhCN.lua
+++ b/SepulcherOfTheFirstOnes/Locales/zhCN.lua
@@ -145,9 +145,11 @@ if L then
 	L.azeroth_new_health_minus = "艾泽拉斯: -%.1f%%  (%d)"
 
 	L.mythic_blood_soak_stage_1 = "第一阶段输血计时条"
-	L.mythic_blood_soak_stage_2 = "第二阶段输血计时条"
-	L.mythic_blood_soak_stage_3 = "第三阶段输血计时条"
 	L.mythic_blood_soak_stage_1_desc = "显示输血计时条，根据 Echo 的首杀所使用的时间轴制作，会在合适的时间点提醒你治疗艾泽拉斯。"
+	L.mythic_blood_soak_stage_2 = "第二阶段输血计时条"
+	L.mythic_blood_soak_stage_2_desc = L.mythic_blood_soak_stage_1_desc
+	L.mythic_blood_soak_stage_3 = "第三阶段输血计时条"
+	L.mythic_blood_soak_stage_3_desc = L.mythic_blood_soak_stage_1_desc
 	L.mythic_blood_soak_bar = "治疗艾泽拉斯"
 
 	L.floors_open = "地板开启"

--- a/SepulcherOfTheFirstOnes/Locales/zhTW.lua
+++ b/SepulcherOfTheFirstOnes/Locales/zhTW.lua
@@ -145,9 +145,11 @@ if L then
 	L.azeroth_new_health_minus = "艾澤拉斯：-%.1f%%  (%d)"
 
 	L.mythic_blood_soak_stage_1 = "第一階段輸血計時器"
-	L.mythic_blood_soak_stage_2 = "第二階段輸血計時器"
-	L.mythic_blood_soak_stage_3 = "第三階段輸血計時器"
 	L.mythic_blood_soak_stage_1_desc = "顯示輸血計時器，根據 Echo 的首殺所使用的時間軸製作，會在適合的時間點提醒你治療艾澤拉斯。"
+	L.mythic_blood_soak_stage_2 = "第二階段輸血計時器"
+	L.mythic_blood_soak_stage_2_desc = L.mythic_blood_soak_stage_1_desc
+	L.mythic_blood_soak_stage_3 = "第三階段輸血計時器"
+	L.mythic_blood_soak_stage_3_desc = L.mythic_blood_soak_stage_1_desc
 	L.mythic_blood_soak_bar = "治療艾澤拉斯"
 
 	L.floors_open = "地板開啟"


### PR DESCRIPTION
After seeing the changes in the new version I noticed that the soak description lines were missing in the second and third stage of the jailer.

![image](https://user-images.githubusercontent.com/16833/170152474-1cc9c3e9-7bfc-4cf2-947a-6de7fae4404f.png)

