### PR TITLE
Changed translation of Alert to differ from Warning

### DIFF
--- a/Plugins/Locales/deDE.lua
+++ b/Plugins/Locales/deDE.lua
@@ -355,7 +355,7 @@ L.oldSounds = "Alte Sounds"
 
 L.Alarm = "Alarm"
 L.Info = "Info"
-L.Alert = "Warnung"
+L.Alert = "Alarmruf"
 L.Long = "Lang"
 L.Warning = "Warnung"
 L.onyou = "Ein Zauber, Stärkungs- oder Schwächungszauber ist auf Dir"


### PR DESCRIPTION
I'm not sure if this is a good translation, sadly usually Alert is translated into German like alarm or warning, which are already taken.
But having translated warning and alert into the same word is imo even worse.