### PR TITLE
Core/BossPrototype: Fix usages of TargetMessageOld where a table of players was targeted

### DIFF
--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -1992,7 +1992,8 @@ do
 	function boss:TargetMessageOld(key, player, color, sound, text, icon, alwaysPlaySound)
 		self:PlaySound(key, sound, nil, not alwaysPlaySound and player)
 		if type(player) == "table" then
-			self:NewTargetsMessage(key, color, player, nil, text, icon)
+			self:NewTargetsMessage(key, color, player, #player, text, icon)
+			twipe(player)
 		else
 			self:TargetMessage(key, color, player, text, icon)
 		end

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -1990,9 +1990,12 @@ do
 	-- @param[opt] icon the message icon (spell id or texture name)
 	-- @bool[opt] alwaysPlaySound if true, play the sound even if player is not you
 	function boss:TargetMessageOld(key, player, color, sound, text, icon, alwaysPlaySound)
-		self:TargetMessage(key, color, player, text, icon)
 		self:PlaySound(key, sound, nil, not alwaysPlaySound and player)
-		if type(player) == "table" then twipe(player) end
+		if type(player) == "table" then
+			self:NewTargetsMessage(key, color, player, nil, text, icon)
+		else
+			self:TargetMessage(key, color, player, text, icon)
+		end
 	end
 
 	local markerIcons = {


### PR DESCRIPTION
A table of players was formerly a valid argument to TargetMessageOld, but would not be a valid argument to TargetMessage. With this PR if a table is passed in then NewTargetsMessage is used instead.

Fixes lua error (one example from here https://github.com/BigWigsMods/LittleWigs/blob/master/Legion/Karazhan/Vizaduum.lua#L109):

```
Message: Interface\AddOns\BigWigs\Core\BossPrototype.lua:2214: bad argument #3 to 'format' (string expected, got table)
Time: Sun Aug 21 23:03:57 2022
Count: 2
Stack: Interface\AddOns\BigWigs\Core\BossPrototype.lua:2214: bad argument #3 to 'format' (string expected, got table)
[string "=[C]"]: ?
[string "@Interface\AddOns\BigWigs\Core\BossPrototype.lua"]:2214: in function 'TargetMessage'
[string "@Interface\AddOns\BigWigs\Core\BossPrototype.lua"]:1993: in function '?'
[string "@Interface\AddOns\DataStore\libs\AceTimer-3.0\AceTimer-3.0.lua"]:55: in function <...\AddOns\DataStore\libs\AceTimer-3.0\AceTimer-3.0.lua:50>

Locals: (*temporary) = "%s: %s"
(*temporary) = "Chaotic Shadows"
(*temporary) = <table> {
 1 = "<playername>"
}
(*temporary) = "string expected, got table"
```