### PR TITLE
Plugins/BossBlock: Show message to user after disconnect or manual change of sound options

### DIFF
--- a/Plugins/BossBlock.lua
+++ b/Plugins/BossBlock.lua
@@ -259,23 +259,35 @@ do
 
 		-- Enable these CVars every time we load just in case some kind of disconnect/etc during the fight left it permanently disabled
 		if self.db.profile.disableSfx then
-			BigWigs:Print('Sound effects were disabled after loading. Enabling SFX.');
-			SetCVar("Sound_EnableSFX", "1")
+			local sfx = GetCVar("Sound_EnableSFX")
+			if sfx == "0" then
+				BigWigs:Print('Sound effects were disabled after loading. Enabling SFX.');
+				SetCVar("Sound_EnableSFX", "1")
+			end
 		end
 		--if self.db.profile.blockTooltipQuests then
 		--	SetCVar("showQuestTrackingTooltips", "1")
 		--end
 		if self.db.profile.disableMusic then
-			BigWigs:Print('Music was disabled after loading. Enabling music.');
-			SetCVar("Sound_EnableMusic", "1")
+			local music = GetCVar("Sound_EnableMusic")
+			if music == "0" then
+				BigWigs:Print('Music was disabled after loading. Enabling music.');
+				SetCVar("Sound_EnableMusic", "1")
+			end
 		end
 		if self.db.profile.disableAmbience then
-			BigWigs:Print('Ambient sound was disabled after loading. Enabling ambient sound.');
-			SetCVar("Sound_EnableAmbience", "1")
+			local ambience = GetCVar("Sound_EnableAmbience")
+			if ambience == "0" then
+				BigWigs:Print('Ambience was disabled after loading. Enabling ambience.');
+				SetCVar("Sound_EnableAmbience", "1")
+			end
 		end
 		if self.db.profile.disableErrorSpeech then
-			BigWigs:Print('Error speech was disabled after loading. Enabling error speech.');
-			SetCVar("Sound_EnableErrorSpeech", "1");
+			local errorSpeech = GetCVar("Sound_EnableErrorSpeech")
+			if errorSpeech == "0" then
+				BigWigs:Print('Error speech was disabled after loading. Enabling error speech.');
+				SetCVar("Sound_EnableErrorSpeech", "1")
+			end
 		end
 
 		self:RegisterEvent("TALKINGHEAD_REQUESTED")

--- a/Plugins/BossBlock.lua
+++ b/Plugins/BossBlock.lua
@@ -258,12 +258,13 @@ do
 		updateProfile()
 
 		-- Enable these CVars every time we load just in case some kind of disconnect/etc during the fight left it permanently disabled
+		-- Additionally, notify the user if a CVar has been force enabled by BossBlock.
 		if self.db.profile.disableSfx then
 			local sfx = GetCVar("Sound_EnableSFX")
 			if sfx == "0" then
-				BigWigs:Print('Sound effects were disabled after loading. Enabling SFX.');
-				SetCVar("Sound_EnableSFX", "1")
+				BigWigs:Print(L.userNotifySfx);
 			end
+			SetCVar("Sound_EnableSFX", "1")
 		end
 		--if self.db.profile.blockTooltipQuests then
 		--	SetCVar("showQuestTrackingTooltips", "1")
@@ -271,23 +272,23 @@ do
 		if self.db.profile.disableMusic then
 			local music = GetCVar("Sound_EnableMusic")
 			if music == "0" then
-				BigWigs:Print('Music was disabled after loading. Enabling music.');
-				SetCVar("Sound_EnableMusic", "1")
+				BigWigs:Print(L.userNotifyMusic);
 			end
+			SetCVar("Sound_EnableMusic", "1")
 		end
 		if self.db.profile.disableAmbience then
 			local ambience = GetCVar("Sound_EnableAmbience")
 			if ambience == "0" then
-				BigWigs:Print('Ambience was disabled after loading. Enabling ambience.');
-				SetCVar("Sound_EnableAmbience", "1")
+				BigWigs:Print(L.userNotifyAmbience);
 			end
+			SetCVar("Sound_EnableAmbience", "1")
 		end
 		if self.db.profile.disableErrorSpeech then
 			local errorSpeech = GetCVar("Sound_EnableErrorSpeech")
 			if errorSpeech == "0" then
-				BigWigs:Print('Error speech was disabled after loading. Enabling error speech.');
-				SetCVar("Sound_EnableErrorSpeech", "1")
+				BigWigs:Print(L.userNotifyErrorSpeech);
 			end
+			SetCVar("Sound_EnableErrorSpeech", "1")
 		end
 
 		self:RegisterEvent("TALKINGHEAD_REQUESTED")

--- a/Plugins/BossBlock.lua
+++ b/Plugins/BossBlock.lua
@@ -259,19 +259,23 @@ do
 
 		-- Enable these CVars every time we load just in case some kind of disconnect/etc during the fight left it permanently disabled
 		if self.db.profile.disableSfx then
+			BigWigs:Print('Sound effects were disabled after loading. Enabling SFX.');
 			SetCVar("Sound_EnableSFX", "1")
 		end
 		--if self.db.profile.blockTooltipQuests then
 		--	SetCVar("showQuestTrackingTooltips", "1")
 		--end
 		if self.db.profile.disableMusic then
+			BigWigs:Print('Music was disabled after loading. Enabling music.');
 			SetCVar("Sound_EnableMusic", "1")
 		end
 		if self.db.profile.disableAmbience then
+			BigWigs:Print('Ambient sound was disabled after loading. Enabling ambient sound.');
 			SetCVar("Sound_EnableAmbience", "1")
 		end
 		if self.db.profile.disableErrorSpeech then
-			SetCVar("Sound_EnableErrorSpeech", "1")
+			BigWigs:Print('Error speech was disabled after loading. Enabling error speech.');
+			SetCVar("Sound_EnableErrorSpeech", "1");
 		end
 
 		self:RegisterEvent("TALKINGHEAD_REQUESTED")

--- a/Plugins/Locales/deDE.lua
+++ b/Plugins/Locales/deDE.lua
@@ -187,6 +187,11 @@ L.blockTalkingHeadRaids = "Schlachtzüge"
 L.blockTalkingHeadTimewalking = "Zeitwanderung (Dungeons & Schlachtzüge)"
 L.blockTalkingHeadScenarios = "Szenarien"
 
+-- L.userNotifySfx = "Sound Effects were disabled by BossBlock, forcing it back on."
+-- L.userNotifyMusic = "Music was disabled by BossBlock, forcing it back on."
+-- L.userNotifyAmbience = "Ambience was disabled by BossBlock, forcing it back on."
+-- L.userNotifyErrorSpeech = "Error speech was disabled by BossBlock, forcing it back on."
+
 L.subzone_grand_bazaar = "Der Große Basar" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_port_of_zandalar = "Der Hafen von Zandalar" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_eastern_transept = "Östliches Transept" -- Auchindoun dungeon (Warlords of Draenor)

--- a/Plugins/Locales/enUS.lua
+++ b/Plugins/Locales/enUS.lua
@@ -186,6 +186,11 @@ L.blockTalkingHeadRaids = "Raids"
 L.blockTalkingHeadTimewalking = "Timewalking (Dungeons & Raids)"
 L.blockTalkingHeadScenarios = "Scenarios"
 
+L.userNotifySfx = "Sound Effects were disabled by BossBlock, forcing it back on."
+L.userNotifyMusic = "Music was disabled by BossBlock, forcing it back on."
+L.userNotifyAmbience = "Ambience was disabled by BossBlock, forcing it back on."
+L.userNotifyErrorSpeech = "Error speech was disabled by BossBlock, forcing it back on."
+
 L.subzone_grand_bazaar = "Grand Bazaar" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_port_of_zandalar = "Port of Zandalar" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_eastern_transept = "Eastern Transept" -- Auchindoun dungeon (Warlords of Draenor)

--- a/Plugins/Locales/esES.lua
+++ b/Plugins/Locales/esES.lua
@@ -187,6 +187,11 @@ L.blockObjectiveTrackerDesc = "El seguimiento de misión se ocultará durante en
 --L.blockTalkingHeadTimewalking = "Timewalking (Dungeons & Raids)"
 --L.blockTalkingHeadScenarios = "Scenarios"
 
+-- L.userNotifySfx = "Sound Effects were disabled by BossBlock, forcing it back on."
+-- L.userNotifyMusic = "Music was disabled by BossBlock, forcing it back on."
+-- L.userNotifyAmbience = "Ambience was disabled by BossBlock, forcing it back on."
+-- L.userNotifyErrorSpeech = "Error speech was disabled by BossBlock, forcing it back on."
+
 L.subzone_grand_bazaar = "Gran Bazar" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_port_of_zandalar = "Puerto de Zandalar" -- Battle of Dazar'alor raid (Battle for Azeroth)
 --L.subzone_eastern_transept = "Eastern Transept" -- Auchindoun dungeon (Warlords of Draenor)

--- a/Plugins/Locales/esMX.lua
+++ b/Plugins/Locales/esMX.lua
@@ -187,6 +187,11 @@ L.blockTalkingHeadRaids = "Bandas"
 L.blockTalkingHeadTimewalking = "Cronoviaje (Calabozos & Bandas)"
 L.blockTalkingHeadScenarios = "Escenarios"
 
+-- L.userNotifySfx = "Sound Effects were disabled by BossBlock, forcing it back on."
+-- L.userNotifyMusic = "Music was disabled by BossBlock, forcing it back on."
+-- L.userNotifyAmbience = "Ambience was disabled by BossBlock, forcing it back on."
+-- L.userNotifyErrorSpeech = "Error speech was disabled by BossBlock, forcing it back on."
+
 L.subzone_grand_bazaar = "Gran Bazar" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_port_of_zandalar = "Puerto de Zandalar" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_eastern_transept = "Transepto del Este" -- Auchindoun dungeon (Warlords of Draenor)

--- a/Plugins/Locales/frFR.lua
+++ b/Plugins/Locales/frFR.lua
@@ -187,6 +187,11 @@ L.blockTalkingHeadRaids = "Raids"
 L.blockTalkingHeadTimewalking = "Marcheurs du temps (donjons & raids)"
 L.blockTalkingHeadScenarios = "Scénarios"
 
+-- L.userNotifySfx = "Sound Effects were disabled by BossBlock, forcing it back on."
+-- L.userNotifyMusic = "Music was disabled by BossBlock, forcing it back on."
+-- L.userNotifyAmbience = "Ambience was disabled by BossBlock, forcing it back on."
+-- L.userNotifyErrorSpeech = "Error speech was disabled by BossBlock, forcing it back on."
+
 L.subzone_grand_bazaar = "Le Grand bazar" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_port_of_zandalar = "Port de Zandalar" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_eastern_transept = "Transept est" -- Auchindoun dungeon (Warlords of Draenor)

--- a/Plugins/Locales/itIT.lua
+++ b/Plugins/Locales/itIT.lua
@@ -187,6 +187,11 @@ L.blockTalkingHeadRaids = "Incursioni"
 L.blockTalkingHeadTimewalking = "Viaggi nel Tempo (Spedizioni & Incursioni)"
 L.blockTalkingHeadScenarios = "Scenari"
 
+-- L.userNotifySfx = "Sound Effects were disabled by BossBlock, forcing it back on."
+-- L.userNotifyMusic = "Music was disabled by BossBlock, forcing it back on."
+-- L.userNotifyAmbience = "Ambience was disabled by BossBlock, forcing it back on."
+-- L.userNotifyErrorSpeech = "Error speech was disabled by BossBlock, forcing it back on."
+
 L.subzone_grand_bazaar = "Gran Bazar" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_port_of_zandalar = "Porto di Zandalar" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_eastern_transept = "Transetto Orientale" -- Auchindoun dungeon (Warlords of Draenor)

--- a/Plugins/Locales/koKR.lua
+++ b/Plugins/Locales/koKR.lua
@@ -187,6 +187,11 @@ L.blockTalkingHeadRaids = "레이드"
 L.blockTalkingHeadTimewalking = "시간여행 (던전 및 레이드)"
 L.blockTalkingHeadScenarios = "시나리오"
 
+-- L.userNotifySfx = "Sound Effects were disabled by BossBlock, forcing it back on."
+-- L.userNotifyMusic = "Music was disabled by BossBlock, forcing it back on."
+-- L.userNotifyAmbience = "Ambience was disabled by BossBlock, forcing it back on."
+-- L.userNotifyErrorSpeech = "Error speech was disabled by BossBlock, forcing it back on."
+
 L.subzone_grand_bazaar = "대시장" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_port_of_zandalar = "잔달라 항구" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_eastern_transept = "동쪽 회랑" -- Auchindoun dungeon (Warlords of Draenor)

--- a/Plugins/Locales/ptBR.lua
+++ b/Plugins/Locales/ptBR.lua
@@ -187,6 +187,11 @@ L.blockTalkingHeadRaids = "Raides"
 L.blockTalkingHeadTimewalking = "Caminhada Temporal (Masmorras & Raides)"
 L.blockTalkingHeadScenarios = "Cenários"
 
+-- L.userNotifySfx = "Sound Effects were disabled by BossBlock, forcing it back on."
+-- L.userNotifyMusic = "Music was disabled by BossBlock, forcing it back on."
+-- L.userNotifyAmbience = "Ambience was disabled by BossBlock, forcing it back on."
+-- L.userNotifyErrorSpeech = "Error speech was disabled by BossBlock, forcing it back on."
+
 L.subzone_grand_bazaar = "Grande Bazar" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_port_of_zandalar = "Porto de Zandalar" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_eastern_transept = "Transepto Oriental" -- Auchindoun dungeon (Warlords of Draenor)

--- a/Plugins/Locales/ruRU.lua
+++ b/Plugins/Locales/ruRU.lua
@@ -187,6 +187,11 @@ L.blockTalkingHeadRaids = "Рейды"
 L.blockTalkingHeadTimewalking = "Путешествия во времени (подземелья и рейды)"
 L.blockTalkingHeadScenarios = "Сценарии"
 
+-- L.userNotifySfx = "Sound Effects were disabled by BossBlock, forcing it back on."
+-- L.userNotifyMusic = "Music was disabled by BossBlock, forcing it back on."
+-- L.userNotifyAmbience = "Ambience was disabled by BossBlock, forcing it back on."
+-- L.userNotifyErrorSpeech = "Error speech was disabled by BossBlock, forcing it back on."
+
 L.subzone_grand_bazaar = "Большой базар" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_port_of_zandalar = "Порт Зандалара" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_eastern_transept = "Восточный трансепт" -- Auchindoun dungeon (Warlords of Draenor)

--- a/Plugins/Locales/zhCN.lua
+++ b/Plugins/Locales/zhCN.lua
@@ -187,6 +187,11 @@ L.blockTalkingHeadRaids = "团队"
 L.blockTalkingHeadTimewalking = "时空漫游（地下城和团队）"
 L.blockTalkingHeadScenarios = "场景事件"
 
+-- L.userNotifySfx = "Sound Effects were disabled by BossBlock, forcing it back on."
+-- L.userNotifyMusic = "Music was disabled by BossBlock, forcing it back on."
+-- L.userNotifyAmbience = "Ambience was disabled by BossBlock, forcing it back on."
+-- L.userNotifyErrorSpeech = "Error speech was disabled by BossBlock, forcing it back on."
+
 L.subzone_grand_bazaar = "百商集市" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_port_of_zandalar = "赞达拉港" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_eastern_transept = "东侧耳堂" -- Auchindoun dungeon (Warlords of Draenor)

--- a/Plugins/Locales/zhTW.lua
+++ b/Plugins/Locales/zhTW.lua
@@ -187,6 +187,11 @@ L.blockTalkingHeadRaids = "團隊副本"
 L.blockTalkingHeadTimewalking = "時光漫遊（地城 & 團隊副本）"
 L.blockTalkingHeadScenarios = "事件"
 
+-- L.userNotifySfx = "Sound Effects were disabled by BossBlock, forcing it back on."
+-- L.userNotifyMusic = "Music was disabled by BossBlock, forcing it back on."
+-- L.userNotifyAmbience = "Ambience was disabled by BossBlock, forcing it back on."
+-- L.userNotifyErrorSpeech = "Error speech was disabled by BossBlock, forcing it back on."
+
 L.subzone_grand_bazaar = "大市集" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_port_of_zandalar = "贊達拉港" -- Battle of Dazar'alor raid (Battle for Azeroth)
 L.subzone_eastern_transept = "東穿堂" -- Auchindoun dungeon (Warlords of Draenor)


### PR DESCRIPTION
Exposing setting of these cvars to the user can prevent confusion if the user has manually changed these settings via the Blizzard UI.
In the case of a disconnect during an encounter, or when the user manually changes one of these cvars and plugins is reloaded, these chat messages will show - prompting the user to update their bigwigs settings.

See #1273 