### PR TITLE
Update BroodkeeperDiurna.lua

### DIFF
--- a/VaultOfTheIncarnates/BroodkeeperDiurna.lua
+++ b/VaultOfTheIncarnates/BroodkeeperDiurna.lua
@@ -171,11 +171,8 @@ function mod:OnEngage()
 	self:CDBar(-25129, 22, L.add_count:format(CL.adds, primalReinforcementsCount, 1), "inv_dragonwhelpproto_blue") -- Primalist Reinforcements / Adds
 	self:CDBar(388716, 26.5, CL.count:format(L.icy_shroud, icyShroudCount)) -- Icy Shroud
 
-	if self:GetOption(primalistMageMarker) then
+	if self:GetOption(primalistMageMarker or stormbringerMarker) then
 		self:RegisterTargetEvents("AddMarking")
-		else if self:GetOption(stormbringerMarker) then
-			self:RegisterTargetEvents("AddMarking")
-		end
 	end
 end
 
@@ -193,7 +190,8 @@ function mod:AddMarking(_, unit, guid)
 				return
 			end
 		end
-		else if guid and not mobCollector[guid] and self:MobId(guid) == 191232 then -- Drakonid Stormbringer
+	else
+		if guid and not mobCollector[guid] and self:MobId(guid) == 191232 then -- Drakonid Stormbringer
 			for i = 3, -1 do -- 3
 				if not stormbringerMarks[i] then
 					mobCollector[guid] = true

--- a/VaultOfTheIncarnates/BroodkeeperDiurna.lua
+++ b/VaultOfTheIncarnates/BroodkeeperDiurna.lua
@@ -143,7 +143,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "IonizingChargeRemoved", 375620)
 	self:Log("SPELL_DAMAGE", "IonizingChargeDamage", 375634)
 	self:Log("SPELL_MISSED", "IonizingChargeDamage", 375634)
-	self:Death("stormbringerDeath", 191232) -- Drakonid Stormbringer
+	self:Death("StormbringerDeath", 191232) -- Drakonid Stormbringer
 
 	-- Stage Two: A Broodkeeper Scorned
 	self:Log("SPELL_AURA_APPLIED", "BroodkeepersFury", 375879)
@@ -173,10 +173,9 @@ function mod:OnEngage()
 
 	if self:GetOption(primalistMageMarker) then
 		self:RegisterTargetEvents("AddMarking")
-	end
-	
-	if self:GetOption(stormbringerMarker) then
-		self:RegisterTargetEvents("AddMarking2")
+		else if self:GetOption(stormbringerMarker) then
+			self:RegisterTargetEvents("AddMarking")
+		end
 	end
 end
 
@@ -194,21 +193,19 @@ function mod:AddMarking(_, unit, guid)
 				return
 			end
 		end
-	end
-end
-
-function mod:AddMarking2(_, unit, guid)
-	if guid and not mobCollector[guid] and self:MobId(guid) == 191232 then -- Drakonid Stormbringer
-		for i = 8, 7, -1 do -- 8, 7
-			if not stormbringerMarks[i] then
-				mobCollector[guid] = true
-				stormbringerMarks[i] = guid
-				self:CustomIcon(stormbringerMarker, unit, i)
-				return
+		else if guid and not mobCollector[guid] and self:MobId(guid) == 191232 then -- Drakonid Stormbringer
+			for i = 3, -1 do -- 3
+				if not stormbringerMarks[i] then
+					mobCollector[guid] = true
+					stormbringerMarks[i] = guid
+					self:CustomIcon(stormbringerMarker, unit, i)
+					return
+				end
 			end
 		end
 	end
 end
+
 
 function mod:PrimalistMageDeath(args)
 	if self:GetOption(primalistMageMarker) then
@@ -221,7 +218,7 @@ function mod:PrimalistMageDeath(args)
 	end
 end
 
-function mod:stormbringerDeath(args)
+function mod:StormbringerDeath(args)
 	if self:GetOption(stormbringerMarker) then
 		for i = 3, -1 do -- 3
 			if stormbringerMarks[i] == args.destGUID then

--- a/VaultOfTheIncarnates/BroodkeeperDiurna.lua
+++ b/VaultOfTheIncarnates/BroodkeeperDiurna.lua
@@ -171,7 +171,7 @@ function mod:OnEngage()
 	self:CDBar(-25129, 22, L.add_count:format(CL.adds, primalReinforcementsCount, 1), "inv_dragonwhelpproto_blue") -- Primalist Reinforcements / Adds
 	self:CDBar(388716, 26.5, CL.count:format(L.icy_shroud, icyShroudCount)) -- Icy Shroud
 
-	if self:GetOption(primalistMageMarker or stormbringerMarker) then
+	if self:GetOption(primalistMageMarker) or self:GetOption(stormbringerMarker) then
 		self:RegisterTargetEvents("AddMarking")
 	end
 end
@@ -190,8 +190,7 @@ function mod:AddMarking(_, unit, guid)
 				return
 			end
 		end
-	else
-		if guid and not mobCollector[guid] and self:MobId(guid) == 191232 then -- Drakonid Stormbringer
+	elseif guid and not mobCollector[guid] and self:MobId(guid) == 191232 then -- Drakonid Stormbringer
 			for i = 3, -1 do -- 3
 				if not stormbringerMarks[i] then
 					mobCollector[guid] = true


### PR DESCRIPTION
Added functionality to mark Drakanid Stormbringer with a Diamond. Useful for heroic/mythic due to needing to interrupt static jolt and being able to auto mark this NPC will allow raiders to easier set up MRT notes for interrupt rotations.