### PR TITLE
Update .luacheckrc for WotLK Classic

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -263,8 +263,4 @@ globals = {
 	"UnitSex",
 	"UnitThreatSituation", -- Cataclysm/Bastion/Sinestra.lua
 	"Minimap", -- Legion/TombOfSargeras/Kiljaeden.lua
-
-	-- LittleWigs
-	"GetNumGossipAvailableQuests", -- TBC/OldHillsbradFoothills/Trash.lua
-	"GetNumGossipActiveQuests", -- TBC/OldHillsbradFoothills/Trash.lua
 }


### PR DESCRIPTION
Removes APIs from luacheck which were only used in LittleWigs for WotLK Classic before https://github.com/BigWigsMods/LittleWigs/pull/872.