### PR TITLE
AhnQirajRuins/Moam: Fix error from a typo

### DIFF
--- a/Classic/AhnQirajRuins/Moam.lua
+++ b/Classic/AhnQirajRuins/Moam.lua
@@ -35,7 +35,7 @@ end
 function mod:Energize(args)
 	-- Adds spawned
 	self:Message(25685, "yellow")
-	self:PlaySouund(25685, "long")
+	self:PlaySound(25685, "long")
 	local duration = 90
 	-- Need to find the mana regen rate because he comes back at 100% regardless
 	-- local unit = self:GetUnitIdByGUID(args.sourceGUID)
@@ -50,6 +50,6 @@ function mod:EnergizeRemoved(args)
 	self:StopBar(args.destName)
 
 	self:Message(25685, "yellow", CL.over:format(args.spellName))
-	self:PlaySouund(25685, "long")
+	self:PlaySound(25685, "long")
 	self:Bar(25685, 90)
 end


### PR DESCRIPTION
Fix typo for Classic/AQ20/Moam:

1x BigWigs_AhnQirajRuins/Moam.lua:53: attempt to call method 'PlaySouund' (a nil value)
[string "@BigWigs_AhnQirajRuins/Moam.lua"]:53: in function `?'
[string "@BigWigs_Core/BossPrototype.lua"]:634: in function <BigWigs_Core/BossPrototype.lua:596>

Locals:
Skipped (In Encounter)