### PR TITLE
Rework Private Aura handling

### DIFF
--- a/Aberrus/EchoOfNeltharion.lua
+++ b/Aberrus/EchoOfNeltharion.lua
@@ -8,6 +8,10 @@ mod:RegisterEnableMob(201668) -- Neltharion
 mod:SetEncounterID(2684)
 mod:SetRespawnTime(30)
 mod:SetStage(1)
+mod:SetPrivateAuraSounds({
+	410966, -- Volcanic Heart
+	{407182, option = 407221}, -- Rushing Darkness
+})
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -134,8 +138,6 @@ function mod:OnEngage()
 	end
 
 	self:RegisterUnitEvent("UNIT_HEALTH", nil, "boss1")
-	self:SetPrivateAuraSound(410953, 410966) -- Volcanic Heart
-	self:SetPrivateAuraSound(407221, 407182) -- Rushing Darkness
 end
 
 --------------------------------------------------------------------------------

--- a/Aberrus/TheForgottenExperiments.lua
+++ b/Aberrus/TheForgottenExperiments.lua
@@ -8,6 +8,9 @@ mod:RegisterEnableMob(200912, 200913, 200918) -- Neldris, Thadrion, Rionthus
 mod:SetEncounterID(2693)
 mod:SetRespawnTime(30)
 mod:SetStage(1)
+mod:SetPrivateAuraSounds({
+	406317, -- Rending Charge
+})
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -73,7 +76,7 @@ function mod:GetOptions()
 		{406311, "TANK"}, -- Infused Strikes
 		407302, -- Infused Explosion
 		-- Neldris
-		{406358, "ICON", "SAY", "SAY_COUNTDOWN", "PRIVATE", "ME_ONLY_EMPHASIZE"}, -- Rending Charge
+		{406358, "PRIVATE", "ICON", "SAY", "SAY_COUNTDOWN", "ME_ONLY_EMPHASIZE"}, -- Rending Charge
 		404472, -- Massive Slam
 		404713, -- Bellowing Roar
 		-- Thadrion
@@ -156,8 +159,6 @@ function mod:OnEngage()
 	self:Bar(404713, self:Mythic() and 6 or 11, CL.count:format(CL.roar, bellowingRoarCount)) -- Bellowing Roar
 	self:Bar(406358, self:Mythic() and 14 or 19, CL.count:format(self:SpellName(406358), rendingChargeCount)) -- Rending Charge
 	self:Bar(404472, self:Mythic() and 24 or 35, CL.count:format(CL.frontal_cone, massiveSlamCount)) -- Massive Slam
-
-	self:SetPrivateAuraSound(406358, 406317) -- Rending Charge
 end
 
 --------------------------------------------------------------------------------

--- a/Amirdrassil/CouncilOfDreams.lua
+++ b/Amirdrassil/CouncilOfDreams.lua
@@ -7,6 +7,9 @@ if not mod then return end
 mod:RegisterEnableMob(208363, 208365, 208367) -- Urctos, Aerwynn, Pip
 mod:SetEncounterID(2728)
 mod:SetRespawnTime(30)
+mod:SetPrivateAuraSounds({
+	418589, -- Polymorph Bomb (Pre-Bomb)
+})
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -85,7 +88,7 @@ function mod:GetOptions()
 		{421029, "CASTBAR", "ME_ONLY_EMPHASIZE"}, -- Song of the Dragon
 		{421032, "SAY"}, -- Captivating Finale
 		{421501, "OFF"}, -- Blink
-		{418720, "SAY_COUNTDOWN", "ME_ONLY_EMPHASIZE", "PRIVATE"}, -- Polymorph Bomb
+		{418720, "PRIVATE", "SAY_COUNTDOWN", "ME_ONLY_EMPHASIZE"}, -- Polymorph Bomb
 		421024, -- Emerald Winds
 		423551, -- Whimsical Gust (Damage)
 	},{
@@ -209,8 +212,6 @@ function mod:OnEngage()
 	self:Bar(421501, self:LFR() and 30.7 or 23) -- Blink
 	self:Bar(418720, self:LFR() and 46.6 or self:Normal() and 35 or 36, CL.count:format(L.polymorph_bomb, polymorphBombCount)) -- Polymorph Bomb
 	self:Bar(421024, self:Mythic() and 43 or self:LFR() and 60.2 or 45.5, CL.count:format(CL.pushback, emeraldWindsCount)) -- Emerald Winds
-
-	self:SetPrivateAuraSound(418720, 418589) -- Polymorph Bomb (Pre-Bomb)
 end
 
 function mod:BigWigs_EncounterEnd()

--- a/Amirdrassil/Fyrakk.lua
+++ b/Amirdrassil/Fyrakk.lua
@@ -8,6 +8,15 @@ mod:RegisterEnableMob(204931) -- Fyrakk
 mod:SetEncounterID(2677)
 mod:SetRespawnTime(30)
 mod:SetStage(1)
+mod:SetPrivateAuraSounds({
+	{414186, extra = {414187, 421825, 421826, 421827, 421828, 421829}}, -- Blaze
+	419060, -- Firestorm
+	{426370, mythic = true}, -- Darkflame Cleave
+	422520, -- Greater Firestorm
+	{428988, "alarm", mythic = true}, -- Molten Eruption
+	{428970, mythic = true}, -- Shadow Cage
+	425525, -- Eternal Firestorm
+})
 
 --------------------------------------------------------------------------------
 -- Timers
@@ -123,7 +132,7 @@ function mod:GetOptions()
 		425483, -- Incinerated (Damage)
 		-- Mythic
 		{430441, "OFF"}, -- Darkflame Shades
-		{426368, "CASTBAR", "PRIVATE"}, -- Darkflame Cleave
+		{426368, "PRIVATE", "CASTBAR"}, -- Darkflame Cleave
 
 		-- Intermission: Amirdrassil in Peril
 		{419144, "CASTBAR"}, -- Corrupt
@@ -289,20 +298,6 @@ function mod:OnEngage()
 	end
 
 	self:RegisterUnitEvent("UNIT_HEALTH", nil, "boss1")
-	self:SetPrivateAuraSound(414186, 414187) -- Blaze
-	self:SetPrivateAuraSound(414186, 421825)
-	self:SetPrivateAuraSound(414186, 421826)
-	self:SetPrivateAuraSound(414186, 421827)
-	self:SetPrivateAuraSound(414186, 421828)
-	self:SetPrivateAuraSound(414186, 421829)
-	self:SetPrivateAuraSound(419506, 419060) -- Firestorm
-	self:SetPrivateAuraSound(422518, 422520) -- Greater Firestorm
-	self:SetPrivateAuraSound(422935, 425525) -- Eternal Firestorm
-	if self:Mythic() then
-		self:SetPrivateAuraSound(426368, 426370) -- Darkflame Cleave
-		self:SetPrivateAuraSound(428971, 428988, "alarm") -- Molten Eruption
-		self:SetPrivateAuraSound(428970, 428970) -- Shadow Cage
-	end
 end
 
 function mod:BigWigs_EncounterEnd()

--- a/Amirdrassil/Fyrakk.lua
+++ b/Amirdrassil/Fyrakk.lua
@@ -13,7 +13,7 @@ mod:SetPrivateAuraSounds({
 	419060, -- Firestorm
 	{426370, mythic = true}, -- Darkflame Cleave
 	422520, -- Greater Firestorm
-	{428988, "alarm", mythic = true}, -- Molten Eruption
+	{428988, mythic = true}, -- Molten Eruption
 	{428970, mythic = true}, -- Shadow Cage
 	425525, -- Eternal Firestorm
 })
@@ -150,7 +150,6 @@ function mod:GetOptions()
 		422524, -- Shadowflame Devastation
 		419123, -- Flamefall
 		-- Mythic
-		{428971, "PRIVATE"}, -- Molten Eruption
 		{428970, "PRIVATE"}, -- Shadow Cage
 
 		-- Stage Three: Shadowflame Incarnate
@@ -172,7 +171,7 @@ function mod:GetOptions()
 		[419144] = -26667, -- Intermission: Amirdrassil in Peril
 		[429906] = "mythic",
 		[422032] = -26668, -- Stage Two: Children of the Stars
-		[428971] = "mythic",
+		[428970] = "mythic",
 		[422935] = -26670, -- Stage Three: Shadowflame Incarnate
 		[423601] = 423601, -- Seed of Amirdrassil
 		[430048] = "mythic",

--- a/Amirdrassil/Larodar.lua
+++ b/Amirdrassil/Larodar.lua
@@ -8,6 +8,12 @@ mod:RegisterEnableMob(208445) -- Larodar, Keeper of the Flame
 mod:SetEncounterID(2731)
 mod:SetRespawnTime(30)
 mod:SetStage(1)
+mod:SetPrivateAuraSounds({
+	420544, -- Scorching Pursuit
+	{421461, "alarm"}, -- Flash Fire
+	{425888, mythic = true}, -- Igniting Growth
+	{428901, mythic = true}, -- Ashen Devastation
+})
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -140,7 +146,7 @@ function mod:GetOptions()
 
 		-- Stage Two: Avatar of Ash
 		427252, -- Falling Embers
-		{427299, "SAY", "SAY_COUNTDOWN", "ME_ONLY_EMPHASIZE"}, -- Flash Fire
+		{427299, "PRIVATE", "SAY", "SAY_COUNTDOWN", "ME_ONLY_EMPHASIZE"}, -- Flash Fire
 		{427306, "SAY"}, -- Encased in Ash
 		427343, -- Fire Whirl
 		429973, -- Smoldering Backdraft
@@ -264,12 +270,6 @@ function mod:OnEngage()
 	end
 
 	self:RegisterUnitEvent("UNIT_HEALTH", nil, "boss1")
-
-	self:SetPrivateAuraSound(420544) -- Scorching Pursuit
-	if self:Mythic() then
-		self:SetPrivateAuraSound(425889, 425888) -- Igniting Growth
-		self:SetPrivateAuraSound(428896, 428901) -- Ashen Devastation
-	end
 end
 
 --------------------------------------------------------------------------------

--- a/Amirdrassil/Larodar.lua
+++ b/Amirdrassil/Larodar.lua
@@ -10,7 +10,7 @@ mod:SetRespawnTime(30)
 mod:SetStage(1)
 mod:SetPrivateAuraSounds({
 	420544, -- Scorching Pursuit
-	{421461, "alarm"}, -- Flash Fire
+	421461, -- Flash Fire
 	{425888, mythic = true}, -- Igniting Growth
 	{428901, mythic = true}, -- Ashen Devastation
 })
@@ -127,7 +127,6 @@ function mod:GetOptions()
 		418520, -- Blistering Splinters
 		426524, -- Fiery Flourish
 		422614, -- Scorching Roots
-		{420544, "PRIVATE"}, -- Scorching Pursuit
 		{418655, "HEALER"}, -- Charred Brambles
 		426387, -- Scorching Bramblethorn
 		{418637, "SAY", "SAY_COUNTDOWN", "ME_ONLY_EMPHASIZE", "CASTBAR"}, -- Furious Charge

--- a/Amirdrassil/Nymue.lua
+++ b/Amirdrassil/Nymue.lua
@@ -8,6 +8,9 @@ mod:RegisterEnableMob(206172) -- Nymue
 mod:SetEncounterID(2708)
 mod:SetRespawnTime(30)
 mod:SetStage(1)
+mod:SetPrivateAuraSounds({
+	427722, -- Weaver's Burden
+})
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -48,7 +51,7 @@ function mod:GetOptions()
 		420846, -- Continuum
 		429615, -- Impending Loom
 		429983, -- Surging Growth
-		{426519, "TANK", "SAY", "ME_ONLY_EMPHASIZE", "PRIVATE"}, -- Weaver's Burden
+		{426519, "PRIVATE", "TANK", "SAY", "ME_ONLY_EMPHASIZE"}, -- Weaver's Burden
 		-- Mythic
 		430563, -- Ephemeral Flora
 		420907, -- Viridian Rain
@@ -119,8 +122,6 @@ function mod:OnEngage()
 		self:Bar(430563, 29, CL.count:format(L.ephemeral_flora, ephemeralFloraCount)) -- Ephemeral Flora
 		self:ScheduleTimer("EphemeralFlora", 29)
 	end
-
-	self:SetPrivateAuraSound(426519, 427722) -- Weaver's Burden
 end
 
 --------------------------------------------------------------------------------

--- a/Amirdrassil/Smolderon.lua
+++ b/Amirdrassil/Smolderon.lua
@@ -8,6 +8,9 @@ mod:RegisterEnableMob(200927)
 mod:SetEncounterID(2824)
 mod:SetRespawnTime(30)
 mod:SetStage(1)
+mod:SetPrivateAuraSounds({
+	{425885, mythic = true}, -- Seeking Inferno (XXX just text and not used currently?)
+})
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -112,8 +115,6 @@ function mod:OnEngage()
 	heatingUpCount = 0
 	overheatedOnMe = false
 	castingWorldInFlames = false
-
-	self:SetPrivateAuraSound(425885, 426010) -- Seeking Inferno
 
 	self:Bar(421455, 10.5, CL.count:format(self:SpellName(421455), overheatedCount)) -- Overheated
 	self:Bar(421343, 13, CL.count:format(L.brand_of_damnation, brandOfDamnationCount)) -- Brand of Damnation

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -1145,7 +1145,7 @@ do
 				local soundModule = core:GetPlugin("Sounds")
 				for _, option in next, self.privateAuraSoundOptions do
 					local spellId = option[1]
-					local default = soundModule:GetDefaultSound(option[2]) or soundModule:GetDefaultSound("privateaura")
+					local default = soundModule:GetDefaultSound("privateaura")
 
 					local key = ("pa_%d"):format(spellId)
 					local sound = soundModule:GetSoundFile(nil, nil, self.db.profile[key] or default)

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -435,10 +435,8 @@ function boss:Disable(isWipe)
 
 		-- Unregister private aura sounds
 		if self.privateAuraSounds then
-			for _, id in next, self.privateAuraSounds do
-				if id then
-					C_UnitAuras.RemovePrivateAuraAppliedSound(id)
-				end
+			for i = 1, #self.privateAuraSounds do
+				C_UnitAuras.RemovePrivateAuraAppliedSound(self.privateAuraSounds[i])
 			end
 			self.privateAuraSounds = nil
 		end
@@ -1150,20 +1148,26 @@ do
 					local key = ("pa_%d"):format(spellId)
 					local sound = soundModule:GetSoundFile(nil, nil, self.db.profile[key] or default)
 					if sound then
-						self.privateAuraSounds[#self.privateAuraSounds + 1] = C_UnitAuras.AddPrivateAuraAppliedSound({
+						local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
 							spellID = spellId,
 							unitToken = "player",
 							soundFileName = sound,
 							outputChannel = "master",
 						})
+						if privateAuraSoundId then
+							self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
+						end
 						if option.extra then
 							for _, id in next, option.extra do
-								self.privateAuraSounds[#self.privateAuraSounds + 1] = C_UnitAuras.AddPrivateAuraAppliedSound({
+								local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
 									spellID = spellId,
 									unitToken = "player",
 									soundFileName = sound,
 									outputChannel = "master",
 								})
+								if privateAuraSoundId then
+									self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
+								end
 							end
 						end
 					end

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -1140,33 +1140,35 @@ do
 
 			if self.privateAuraSoundOptions and not self.privateAuraSounds then
 				self.privateAuraSounds = {}
-				local soundModule = core:GetPlugin("Sounds")
-				for _, option in next, self.privateAuraSoundOptions do
-					local spellId = option[1]
-					local default = soundModule:GetDefaultSound("privateaura")
+				local soundModule = core:GetPlugin("Sounds", true)
+				if soundModule then
+					for _, option in next, self.privateAuraSoundOptions do
+						local spellId = option[1]
+						local default = soundModule:GetDefaultSound("privateaura")
 
-					local key = ("pa_%d"):format(spellId)
-					local sound = soundModule:GetSoundFile(nil, nil, self.db.profile[key] or default)
-					if sound then
-						local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
-							spellID = spellId,
-							unitToken = "player",
-							soundFileName = sound,
-							outputChannel = "master",
-						})
-						if privateAuraSoundId then
-							self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
-						end
-						if option.extra then
-							for _, id in next, option.extra do
-								local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
-									spellID = spellId,
-									unitToken = "player",
-									soundFileName = sound,
-									outputChannel = "master",
-								})
-								if privateAuraSoundId then
-									self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
+						local key = ("pa_%d"):format(spellId)
+						local sound = soundModule:GetSoundFile(nil, nil, self.db.profile[key] or default)
+						if sound then
+							local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
+								spellID = spellId,
+								unitToken = "player",
+								soundFileName = sound,
+								outputChannel = "master",
+							})
+							if privateAuraSoundId then
+								self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
+							end
+							if option.extra then
+								for _, id in next, option.extra do
+									local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
+										spellID = spellId,
+										unitToken = "player",
+										soundFileName = sound,
+										outputChannel = "master",
+									})
+									if privateAuraSoundId then
+										self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
+									end
 								end
 							end
 						end

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -286,6 +286,15 @@ function boss:SetAllowWin(bool)
 	end
 end
 
+function boss:SetPrivateAuraSounds(opts)
+	for i = 1, #opts do
+		if type(opts[i]) ~= "table" then
+			opts[i] = { opts[i] }
+		end
+	end
+	self.privateAuraSoundOptions = opts
+end
+
 --- Check if a module option is enabled.
 -- This is a wrapper around the self.db.profile[key] table.
 -- @return boolean or number, depending on option type
@@ -424,10 +433,12 @@ function boss:Disable(isWipe)
 			end
 		end
 
-		-- Remove all private aura sounds
+		-- Unregister private aura sounds
 		if self.privateAuraSounds then
 			for _, id in next, self.privateAuraSounds do
-				C_UnitAuras.RemovePrivateAuraAppliedSound(id)
+				if id then
+					C_UnitAuras.RemovePrivateAuraAppliedSound(id)
+				end
 			end
 			self.privateAuraSounds = nil
 		end
@@ -1128,6 +1139,36 @@ do
 			self.isEngaged = true
 
 			self:Debug(":Engage", "noEngage:", noEngage, self:GetEncounterID(), self.moduleName)
+
+			if self.privateAuraSoundOptions and not self.privateAuraSounds then
+				self.privateAuraSounds = {}
+				local soundModule = core:GetPlugin("Sounds")
+				for _, option in next, self.privateAuraSoundOptions do
+					local spellId = option[1]
+					local default = soundModule:GetDefaultSound(option[2]) or soundModule:GetDefaultSound("privateaura")
+
+					local key = ("pa_%d"):format(spellId)
+					local sound = soundModule:GetSoundFile(nil, nil, self.db.profile[key] or default)
+					if sound then
+						self.privateAuraSounds[#self.privateAuraSounds + 1] = C_UnitAuras.AddPrivateAuraAppliedSound({
+							spellID = spellId,
+							unitToken = "player",
+							soundFileName = sound,
+							outputChannel = "master",
+						})
+						if option.extra then
+							for _, id in next, option.extra do
+								self.privateAuraSounds[#self.privateAuraSounds + 1] = C_UnitAuras.AddPrivateAuraAppliedSound({
+									spellID = spellId,
+									unitToken = "player",
+									soundFileName = sound,
+									outputChannel = "master",
+								})
+							end
+						end
+					end
+				end
+			end
 
 			if not noEngage or noEngage ~= "NoEngage" then
 				updateData(self)
@@ -3257,25 +3298,6 @@ end
 -- @string[opt] channel the channel the sound should play on, defaults to "Master"
 function boss:PlaySoundFile(sound, channel)
 	PlaySoundFile(sound, channel or "Master")
-end
-
---- Register a sound to be played when a Private Aura is applied to you.
--- @param key the option key
--- @number[opt] spellId the spell id of the Private Aura if different from the key
--- @string[opt] soundCategory the sound to play, defaults to "warning"
-function boss:SetPrivateAuraSound(key, spellId, soundCategory)
-	if checkFlag(self, key, C.SOUND) then
-		local soundsModule = core:GetPlugin("Sounds", true)
-		if soundsModule then
-			if not self.privateAuraSounds then self.privateAuraSounds = {} end
-			self.privateAuraSounds[#self.privateAuraSounds + 1] = C_UnitAuras.AddPrivateAuraAppliedSound({
-				spellID = spellId or key,
-				unitToken = "player",
-				soundFileName = soundsModule:GetSoundFile(self, key, soundCategory or "warning"),
-				outputChannel = "master",
-			})
-		end
-	end
 end
 
 do

--- a/Core/BossPrototype_Classic.lua
+++ b/Core/BossPrototype_Classic.lua
@@ -507,10 +507,8 @@ function boss:Disable(isWipe)
 
 		-- Unregister private aura sounds
 		if self.privateAuraSounds then
-			for _, id in next, self.privateAuraSounds do
-				if id then
-					C_UnitAuras.RemovePrivateAuraAppliedSound(id)
-				end
+			for i = 1, #self.privateAuraSounds do
+				C_UnitAuras.RemovePrivateAuraAppliedSound(self.privateAuraSounds[i])
 			end
 			self.privateAuraSounds = nil
 		end
@@ -1224,20 +1222,26 @@ do
 					local key = ("pa_%d"):format(spellId)
 					local sound = soundModule:GetSoundFile(nil, nil, self.db.profile[key] or default)
 					if sound then
-						self.privateAuraSounds[#self.privateAuraSounds + 1] = C_UnitAuras.AddPrivateAuraAppliedSound({
+						local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
 							spellID = spellId,
 							unitToken = "player",
 							soundFileName = sound,
 							outputChannel = "master",
 						})
+						if privateAuraSoundId then
+							self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
+						end
 						if option.extra then
 							for _, id in next, option.extra do
-								self.privateAuraSounds[#self.privateAuraSounds + 1] = C_UnitAuras.AddPrivateAuraAppliedSound({
+								local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
 									spellID = spellId,
 									unitToken = "player",
 									soundFileName = sound,
 									outputChannel = "master",
 								})
+								if privateAuraSoundId then
+									self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
+								end
 							end
 						end
 					end

--- a/Core/BossPrototype_Classic.lua
+++ b/Core/BossPrototype_Classic.lua
@@ -1214,33 +1214,35 @@ do
 
 			if self.privateAuraSoundOptions and not self.privateAuraSounds then
 				self.privateAuraSounds = {}
-				local soundModule = core:GetPlugin("Sounds")
-				for _, option in next, self.privateAuraSoundOptions do
-					local spellId = option[1]
-					local default = soundModule:GetDefaultSound("privateaura")
+				local soundModule = core:GetPlugin("Sounds", true)
+				if soundModule then
+					for _, option in next, self.privateAuraSoundOptions do
+						local spellId = option[1]
+						local default = soundModule:GetDefaultSound("privateaura")
 
-					local key = ("pa_%d"):format(spellId)
-					local sound = soundModule:GetSoundFile(nil, nil, self.db.profile[key] or default)
-					if sound then
-						local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
-							spellID = spellId,
-							unitToken = "player",
-							soundFileName = sound,
-							outputChannel = "master",
-						})
-						if privateAuraSoundId then
-							self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
-						end
-						if option.extra then
-							for _, id in next, option.extra do
-								local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
-									spellID = spellId,
-									unitToken = "player",
-									soundFileName = sound,
-									outputChannel = "master",
-								})
-								if privateAuraSoundId then
-									self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
+						local key = ("pa_%d"):format(spellId)
+						local sound = soundModule:GetSoundFile(nil, nil, self.db.profile[key] or default)
+						if sound then
+							local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
+								spellID = spellId,
+								unitToken = "player",
+								soundFileName = sound,
+								outputChannel = "master",
+							})
+							if privateAuraSoundId then
+								self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
+							end
+							if option.extra then
+								for _, id in next, option.extra do
+									local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
+										spellID = spellId,
+										unitToken = "player",
+										soundFileName = sound,
+										outputChannel = "master",
+									})
+									if privateAuraSoundId then
+										self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
+									end
 								end
 							end
 						end

--- a/Core/BossPrototype_Classic.lua
+++ b/Core/BossPrototype_Classic.lua
@@ -358,6 +358,15 @@ function boss:SetAllowWin(bool)
 	end
 end
 
+function boss:SetPrivateAuraSounds(opts)
+	for i = 1, #opts do
+		if type(opts[i]) ~= "table" then
+			opts[i] = { opts[i] }
+		end
+	end
+	self.privateAuraSoundOptions = opts
+end
+
 --- Check if a module option is enabled.
 -- This is a wrapper around the self.db.profile[key] table.
 -- @return boolean or number, depending on option type
@@ -496,10 +505,12 @@ function boss:Disable(isWipe)
 			end
 		end
 
-		-- Remove all private aura sounds
+		-- Unregister private aura sounds
 		if self.privateAuraSounds then
 			for _, id in next, self.privateAuraSounds do
-				C_UnitAuras.RemovePrivateAuraAppliedSound(id)
+				if id then
+					C_UnitAuras.RemovePrivateAuraAppliedSound(id)
+				end
 			end
 			self.privateAuraSounds = nil
 		end
@@ -1202,6 +1213,36 @@ do
 			self.isEngaged = true
 
 			self:Debug(":Engage", "noEngage:", noEngage, self:GetEncounterID(), self.moduleName)
+
+			if self.privateAuraSoundOptions and not self.privateAuraSounds then
+				self.privateAuraSounds = {}
+				local soundModule = core:GetPlugin("Sounds")
+				for _, option in next, self.privateAuraSoundOptions do
+					local spellId = option[1]
+					local default = soundModule:GetDefaultSound("privateaura")
+
+					local key = ("pa_%d"):format(spellId)
+					local sound = soundModule:GetSoundFile(nil, nil, self.db.profile[key] or default)
+					if sound then
+						self.privateAuraSounds[#self.privateAuraSounds + 1] = C_UnitAuras.AddPrivateAuraAppliedSound({
+							spellID = spellId,
+							unitToken = "player",
+							soundFileName = sound,
+							outputChannel = "master",
+						})
+						if option.extra then
+							for _, id in next, option.extra do
+								self.privateAuraSounds[#self.privateAuraSounds + 1] = C_UnitAuras.AddPrivateAuraAppliedSound({
+									spellID = spellId,
+									unitToken = "player",
+									soundFileName = sound,
+									outputChannel = "master",
+								})
+							end
+						end
+					end
+				end
+			end
 
 			if not noEngage or noEngage ~= "NoEngage" then
 				updateData(self)
@@ -3264,25 +3305,6 @@ end
 -- @string[opt] channel the channel the sound should play on, defaults to "Master"
 function boss:PlaySoundFile(sound, channel)
 	PlaySoundFile(sound, channel or "Master")
-end
-
---- Register a sound to be played when a Private Aura is applied to you.
--- @param key the option key
--- @number[opt] spellId the spell id of the Private Aura if different from the key
--- @string[opt] soundCategory the sound to play, defaults to "warning"
-function boss:SetPrivateAuraSound(key, spellId, soundCategory)
-	if checkFlag(self, key, C.SOUND) then
-		local soundsModule = core:GetPlugin("Sounds", true)
-		if soundsModule then
-			if not self.privateAuraSounds then self.privateAuraSounds = {} end
-			self.privateAuraSounds[#self.privateAuraSounds + 1] = C_UnitAuras.AddPrivateAuraAppliedSound({
-				spellID = spellId or key,
-				unitToken = "player",
-				soundFileName = soundsModule:GetSoundFile(self, key, soundCategory or "warning"),
-				outputChannel = "master",
-			})
-		end
-	end
 end
 
 do

--- a/Locales/deDE.lua
+++ b/Locales/deDE.lua
@@ -95,6 +95,8 @@ L.test = "Testen"
 L.resetPositions = "Positionen zurücksetzen"
 L.colors = "Farben"
 L.selectEncounter = "Wähle Begegnung"
+--L.privateAuraSounds = "Private Aura Sounds"
+--L.privateAuraSounds_desc = "Private auras can't be tracked normally, but you can set a sound to be played when you are targeted with the ability."
 L.listAbilities = "Fähigkeiten im Chat auflisten"
 
 L.dbmFaker = "Täusche DBM Nutzung vor"

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -94,6 +94,8 @@ L.test = "Test"
 L.resetPositions = "Reset positions"
 L.colors = "Colors"
 L.selectEncounter = "Select encounter"
+L.privateAuraSounds = "Private Aura Sounds"
+L.privateAuraSounds_desc = "Private auras can't be tracked normally, but you can set a sound to be played when you are targeted with the ability."
 L.listAbilities = "List abilities in group chat"
 
 L.dbmFaker = "Pretend I'm using DBM"

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -161,7 +161,7 @@ L.ME_ONLY_EMPHASIZE_desc = "Enabling this will emphasize any messages associated
 L.NAMEPLATEBAR = "Nameplate Bars"
 L.NAMEPLATEBAR_desc = "Bars are sometimes attached to nameplates when more than one mob casts the same spell. If this ability is accompanied by a nameplate bar that you want to hide, disable this option."
 L.PRIVATE = "Private Aura"
-L.PRIVATE_desc = "Private auras can't be tracked normally, but the \"on you\" sound (Warning) can be set in the Sound tab."
+L.PRIVATE_desc = "These settings are for general cast alerts and bars only!\n\nYou can change the sound to play when you are targeted by this ability by selecting \"Private Aura Sounds\" in the \"Select encounter\" dropdown in the top right."
 
 L.advanced = "Advanced options"
 L.back = "<< Back"

--- a/Locales/esES.lua
+++ b/Locales/esES.lua
@@ -95,6 +95,8 @@ L.test = "Probar"
 L.resetPositions = "Reiniciar posiciones"
 L.colors = "Colores"
 L.selectEncounter = "Seleccionar encuentro"
+--L.privateAuraSounds = "Private Aura Sounds"
+--L.privateAuraSounds_desc = "Private auras can't be tracked normally, but you can set a sound to be played when you are targeted with the ability."
 L.listAbilities = "Listar las habilidades en el chat"
 
 L.dbmFaker = "Fingir que estoy usando DBM"

--- a/Locales/esMX.lua
+++ b/Locales/esMX.lua
@@ -95,6 +95,8 @@ L.test = "Probar"
 L.resetPositions = "Restablecer posiciones"
 L.colors = "Colores"
 L.selectEncounter = "Seleccionar encuentro"
+--L.privateAuraSounds = "Private Aura Sounds"
+--L.privateAuraSounds_desc = "Private auras can't be tracked normally, but you can set a sound to be played when you are targeted with the ability."
 L.listAbilities = "Listar las habilidades en el chat"
 
 L.dbmFaker = "Fingir que estoy usando DBM"

--- a/Locales/frFR.lua
+++ b/Locales/frFR.lua
@@ -95,6 +95,8 @@ L.test = "Test"
 L.resetPositions = "Réinitialiser les positions"
 L.colors = "Couleurs"
 L.selectEncounter = "Sélectionnez une rencontre"
+--L.privateAuraSounds = "Private Aura Sounds"
+--L.privateAuraSounds_desc = "Private auras can't be tracked normally, but you can set a sound to be played when you are targeted with the ability."
 L.listAbilities = "Lister les techniques dans la discussion de groupe"
 
 L.dbmFaker = "Prétendre d'utiliser DBM"

--- a/Locales/itIT.lua
+++ b/Locales/itIT.lua
@@ -95,6 +95,8 @@ L.test = "Prova"
 L.resetPositions = "Ripristina le Posizioni"
 L.colors = "Colori"
 L.selectEncounter = "Seleziona il Combattimento"
+--L.privateAuraSounds = "Private Aura Sounds"
+--L.privateAuraSounds_desc = "Private auras can't be tracked normally, but you can set a sound to be played when you are targeted with the ability."
 L.listAbilities = "Elenca le Abilità nella Chat"
 
 L.dbmFaker = "Fingi di usare DBM"

--- a/Locales/koKR.lua
+++ b/Locales/koKR.lua
@@ -95,6 +95,8 @@ L.test = "테스트"
 L.resetPositions = "위치 초기화"
 L.colors = "색상"
 L.selectEncounter = "우두머리 전투 선택"
+--L.privateAuraSounds = "Private Aura Sounds"
+--L.privateAuraSounds_desc = "Private auras can't be tracked normally, but you can set a sound to be played when you are targeted with the ability."
 L.listAbilities = "파티/공격대 대화에 능력 나열하기"
 
 L.dbmFaker = "DBM을 사용 중인 것처럼 위장하기"

--- a/Locales/ptBR.lua
+++ b/Locales/ptBR.lua
@@ -95,6 +95,8 @@ L.test = "Teste"
 L.resetPositions = "Resetar posições"
 L.colors = "Cores"
 L.selectEncounter = "Selecionar Encontro"
+--L.privateAuraSounds = "Private Aura Sounds"
+--L.privateAuraSounds_desc = "Private auras can't be tracked normally, but you can set a sound to be played when you are targeted with the ability."
 L.listAbilities = "Listar habilidades no bate-papo do grupo"
 
 L.dbmFaker = "Faz de conta que eu estou usando DBM"

--- a/Locales/ruRU.lua
+++ b/Locales/ruRU.lua
@@ -95,6 +95,8 @@ L.test = "Тест"
 L.resetPositions = "Сброс позиции"
 L.colors = "Цвета"
 L.selectEncounter = "Выберите схватку"
+--L.privateAuraSounds = "Private Aura Sounds"
+--L.privateAuraSounds_desc = "Private auras can't be tracked normally, but you can set a sound to be played when you are targeted with the ability."
 L.listAbilities = "Вывести способности в групповой чат"
 
 L.dbmFaker = "Маскировка под DBM"

--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -95,6 +95,8 @@ L.test = "测试"
 L.resetPositions = "重置位置"
 L.colors = "颜色"
 L.selectEncounter = "选择战斗"
+--L.privateAuraSounds = "Private Aura Sounds"
+--L.privateAuraSounds_desc = "Private auras can't be tracked normally, but you can set a sound to be played when you are targeted with the ability."
 L.listAbilities = "列出技能到团队聊天"
 
 L.dbmFaker = "伪装成 DBM 用户"

--- a/Locales/zhTW.lua
+++ b/Locales/zhTW.lua
@@ -95,6 +95,8 @@ L.test = "測試"
 L.resetPositions = "重置位置"
 L.colors = "顏色"
 L.selectEncounter = "選擇戰鬥"
+--L.privateAuraSounds = "Private Aura Sounds"
+--L.privateAuraSounds_desc = "Private auras can't be tracked normally, but you can set a sound to be played when you are targeted with the ability."
 L.listAbilities = "將技能列表發送到團隊聊天頻道"
 
 L.dbmFaker = "假裝我是 DBM 用戶"

--- a/NerubarPalace/Kyveza.lua
+++ b/NerubarPalace/Kyveza.lua
@@ -9,6 +9,10 @@ if not mod then return end
 mod:RegisterEnableMob(217748) -- Nexus-Princess Ky'veza
 mod:SetEncounterID(2920)
 mod:SetRespawnTime(30)
+mod:SetPrivateAuraSounds({
+	438141, -- Twilight Massacre
+	{435534, extra = {436663, 436664, 436665, 436666, 436671, 436677}}, -- Regicide
+})
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -49,7 +53,7 @@ function mod:GetOptions()
 		{440576, "TANK"}, -- Chasmal Gash
 		-- Stage Two: Starless Night
 		435405, -- Starless Night
-		{435534, "PRIVATE"}, -- Regicide
+		-- {435534, "PRIVATE"}, -- Regicide XXX only a sound right now
 		442277, -- Eternal Night
 	}, {
 		[436867] = -28741,
@@ -86,15 +90,6 @@ function mod:OnEngage()
 	self:Bar(438245, 34.3, CL.count:format(self:SpellName(438245), twilightMassacreCount)) -- Twilight Massacre
 	self:Bar(439576, 45.3, CL.count:format(self:SpellName(439576), nexusDaggersCount)) -- Nexus Daggers
 	self:Bar(435405, 86.1, CL.count:format(self:SpellName(435405), starlessNightCount)) -- Starless Night
-
-	self:SetPrivateAuraSound(438245, 438141) -- Twilight Massacre
-	self:SetPrivateAuraSound(435534) -- Regicide
-	self:SetPrivateAuraSound(435534, 436663)
-	self:SetPrivateAuraSound(435534, 436664)
-	self:SetPrivateAuraSound(435534, 436665)
-	self:SetPrivateAuraSound(435534, 436666)
-	self:SetPrivateAuraSound(435534, 436671)
-	self:SetPrivateAuraSound(435534, 436677)
 end
 
 --------------------------------------------------------------------------------

--- a/NerubarPalace/Ovinax.lua
+++ b/NerubarPalace/Ovinax.lua
@@ -9,6 +9,9 @@ if not mod then return end
 mod:RegisterEnableMob(214506) -- Eggtender Ovi'nax
 mod:SetEncounterID(2919)
 mod:SetRespawnTime(30)
+mod:SetPrivateAuraSounds({
+	440421, -- Experimental Dosage
+})
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -86,8 +89,6 @@ function mod:OnEngage()
 	self:Bar(446349, 15, CL.count:format(self:SpellName(446349), unstableWebCount)) -- Unstable Web
 	self:Bar(442432, 20, CL.count:format(self:SpellName(442432), ingestBlackBloodCount)) -- Ingest Black Blood
 	self:Bar(442526, 51, CL.count:format(self:SpellName(442526), experimentalDosageCount)) -- Experimental Dosage
-
-	self:SetPrivateAuraSound(442526, 440421) -- Experimental Dosage
 end
 
 --------------------------------------------------------------------------------

--- a/NerubarPalace/Rashanan.lua
+++ b/NerubarPalace/Rashanan.lua
@@ -9,6 +9,11 @@ if not mod then return end
 mod:RegisterEnableMob(214504) -- Rasha'nan
 mod:SetEncounterID(2918)
 mod:SetRespawnTime(30)
+mod:SetPrivateAuraSounds({
+	439790, -- Rolling Acid
+	{439815, extra = {455284}}, -- Infested Spawn
+	{439783, extra = {434090}}, -- Spinneret's Strands (XXX are both used?)
+})
 
 --------------------------------------------------------------------------------
 -- Locals
@@ -98,11 +103,6 @@ function mod:OnEngage()
 	self:CDBar(439811, timers[439811][erosiveSprayCount], CL.count:format(self:SpellName(439811), erosiveSprayCount)) -- Erosive Spray
 	self:CDBar(439784, timers[439784][spinneretsStrandsCount], CL.count:format(self:SpellName(439784), spinneretsStrandsCount)) -- Spinneret's Strands
 	self:CDBar(439795, timers[439795][webReaveCount], CL.count:format(self:SpellName(439795), webReaveCount)) -- Web Reave
-
-
-	self:SetPrivateAuraSound(455373, 439815) --  Infested Spawn
-	self:SetPrivateAuraSound(439784, 439783) --  Spinneret's Strands
-	self:SetPrivateAuraSound(439784, 434090)
 end
 
 --------------------------------------------------------------------------------

--- a/Options/Libs/AceGUIWidget-SharedDropdown.lua
+++ b/Options/Libs/AceGUIWidget-SharedDropdown.lua
@@ -1,0 +1,324 @@
+-- soooooo hacky, AceGUIWidget-DropDown with a single shared pullout!
+-- removes the extra overhead when loading many LSM (or whatever) dropdowns in a layout
+-- uses the last :SetList as the pullout for _every_ SharedDropdown, GOOD LUCK EVERYONE
+
+local AceGUI = LibStub("AceGUI-3.0")
+
+-- Lua APIs
+local select, pairs, ipairs, type, tostring = select, pairs, ipairs, type, tostring
+local tsort = table.sort
+
+-- WoW APIs
+local UIParent, CreateFrame = UIParent, CreateFrame
+local _G = _G
+
+local function fixlevels(parent, ...)
+	local i = 1
+	local child = select(i, ...)
+	while child do
+		child:SetFrameLevel(parent:GetFrameLevel() + 1)
+		fixlevels(child, child:GetChildren())
+		i = i + 1
+		child = select(i, ...)
+	end
+end
+
+do
+	local widgetType = "SharedDropdown"
+	local widgetVersion = 1
+
+	--[[ Static data ]]--
+
+	local _pullout = AceGUI:Create("Dropdown-Pullout")
+	_pullout:SetCallback("OnOpen", function(this)
+		local self = this.userdata.obj
+
+		local value = self.value
+		for i, item in this:IterateItems() do
+			item:SetValue(item.userdata.value == value)
+		end
+
+		self.open = true
+		self:Fire("OnOpened")
+	end)
+	_pullout:SetCallback("OnClose", function(this)
+		local self = this.userdata.obj
+		self.open = nil
+		self:Fire("OnClosed")
+	end)
+
+	--[[ UI event handler ]]--
+
+	local function Control_OnEnter(this)
+		this.obj.button:LockHighlight()
+		this.obj:Fire("OnEnter")
+	end
+
+	local function Control_OnLeave(this)
+		this.obj.button:UnlockHighlight()
+		this.obj:Fire("OnLeave")
+	end
+
+	local function Dropdown_OnHide(this)
+		local self = this.obj
+		if self.open then
+			_pullout:Close()
+		end
+	end
+
+	local function Dropdown_TogglePullout(this)
+		local self = this.obj
+		_pullout.userdata.obj = self
+
+		if self.open then
+			self.open = nil
+			_pullout:Close()
+			AceGUI:ClearFocus()
+		else
+			self.open = true
+			_pullout.frame:SetFrameLevel(self.frame:GetFrameLevel() + 1)
+			fixlevels(_pullout.frame, _pullout.frame:GetChildren())
+			_pullout:SetWidth(self.pulloutWidth or self.frame:GetWidth())
+			_pullout:Open("TOPLEFT", self.frame, "BOTTOMLEFT", 0, self.label:IsShown() and -2 or 0)
+			_pullout.scrollStatus.scrollvalue = 0
+			_pullout.scrollStatus.offset = 0
+			_pullout:FixScroll()
+			AceGUI:SetFocus(self)
+		end
+	end
+
+	local function OnItemValueChanged(this, event, checked)
+		local self = _pullout.userdata.obj
+
+		if checked then
+			self:SetValue(this.userdata.value)
+			self:Fire("OnValueChanged", this.userdata.value)
+		else
+			this:SetValue(true)
+		end
+		if self.open then
+			_pullout:Close()
+		end
+	end
+
+	--[[ Exported methods ]]--
+
+	-- exported, AceGUI callback
+	local function OnAcquire(self)
+		self:SetHeight(44)
+		self:SetWidth(200)
+		self:SetLabel()
+		self:SetPulloutWidth(nil)
+		self.list = {}
+	end
+
+	-- exported, AceGUI callback
+	local function OnRelease(self)
+		if self.open then
+			_pullout:Close()
+		end
+
+		self:SetText("")
+		self:SetDisabled(false)
+
+		self.value = nil
+		self.list = nil
+		self.open = nil
+
+		self.frame:ClearAllPoints()
+		self.frame:Hide()
+	end
+
+	-- exported
+	local function SetDisabled(self, disabled)
+		self.disabled = disabled
+		if disabled then
+			self.text:SetTextColor(0.5, 0.5, 0.5)
+			self.button:Disable()
+			self.button_cover:Disable()
+			self.label:SetTextColor(0.5, 0.5, 0.5)
+		else
+			self.button:Enable()
+			self.button_cover:Enable()
+			self.label:SetTextColor(1, 0.82, 0)
+			self.text:SetTextColor(1, 1, 1)
+		end
+	end
+
+	-- exported
+	local function ClearFocus(self)
+		if self.open then
+			_pullout:Close()
+		end
+	end
+
+	-- exported
+	local function SetText(self, text)
+		self.text:SetText(text or "")
+	end
+
+	-- exported
+	local function SetLabel(self, text)
+		if text and text ~= "" then
+			self.label:SetText(text)
+			self.label:Show()
+			self.dropdown:SetPoint("TOPLEFT", self.frame, "TOPLEFT" ,-15, -14)
+			self:SetHeight(40)
+			self.alignoffset = 26
+		else
+			self.label:SetText("")
+			self.label:Hide()
+			self.dropdown:SetPoint("TOPLEFT", self.frame ,"TOPLEFT", -15, 0)
+			self:SetHeight(26)
+			self.alignoffset = 12
+		end
+	end
+
+	-- exported
+	local function SetValue(self, value)
+		self:SetText(self.list[value] or "")
+		self.value = value
+	end
+
+	-- exported
+	local function GetValue(self)
+		return self.value
+	end
+
+	local function AddListItem(self, value, text, itemType)
+		if not itemType then itemType = "Dropdown-Item-Toggle" end
+		local exists = AceGUI:GetWidgetVersion(itemType)
+		if not exists then error(("The given item type, %q, does not exist within AceGUI-3.0"):format(tostring(itemType)), 2) end
+
+		local item = AceGUI:Create(itemType)
+		item:SetText(text)
+		-- item.userdata.obj = self
+		item.userdata.value = value
+		item:SetCallback("OnValueChanged", OnItemValueChanged)
+		_pullout:AddItem(item)
+	end
+
+	local sortlist = {}
+	local function sortTbl(x,y)
+		local num1, num2 = tonumber(x), tonumber(y)
+		if num1 and num2 then -- numeric comparison, either two numbers or numeric strings
+			return num1 < num2
+		else -- compare everything else tostring'ed
+			return tostring(x) < tostring(y)
+		end
+	end
+	-- exported
+	local function SetList(self, list, order, itemType)
+		self.list = list or {}
+		if list and self.list == _pullout.list and #list == #self.list then return end
+		_pullout.list = self.list
+		_pullout:Clear()
+		if not list then return end
+
+		if type(order) ~= "table" then
+			for v in pairs(list) do
+				sortlist[#sortlist + 1] = v
+			end
+			tsort(sortlist, sortTbl)
+
+			for i, key in ipairs(sortlist) do
+				AddListItem(self, key, list[key], itemType)
+				sortlist[i] = nil
+			end
+		else
+			for i, key in ipairs(order) do
+				AddListItem(self, key, list[key], itemType)
+			end
+		end
+	end
+
+	-- exported
+	local function SetPulloutWidth(self, width)
+		self.pulloutWidth = width
+	end
+
+	--[[ Constructor ]]--
+
+	local function Constructor()
+		local count = AceGUI:GetNextWidgetNum(widgetType)
+		local frame = CreateFrame("Frame", nil, UIParent)
+		local dropdown = CreateFrame("Frame", "AceGUI30SharedDropdown" .. count, frame, "UIDropDownMenuTemplate")
+
+		local self = {}
+		self.type = widgetType
+		self.frame = frame
+		self.dropdown = dropdown
+		self.count = count
+		frame.obj = self
+		dropdown.obj = self
+
+		self.OnRelease = OnRelease
+		self.OnAcquire = OnAcquire
+
+		self.ClearFocus = ClearFocus
+
+		self.SetText  = SetText
+		self.SetValue = SetValue
+		self.GetValue = GetValue
+		self.SetList = SetList
+		self.SetLabel = SetLabel
+		self.SetDisabled = SetDisabled
+		self.SetPulloutWidth = SetPulloutWidth
+
+		self.alignoffset = 26
+
+		frame:SetScript("OnHide", Dropdown_OnHide)
+
+		dropdown:ClearAllPoints()
+		dropdown:SetPoint("TOPLEFT", frame, "TOPLEFT", -15, 0)
+		dropdown:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", 17, 0)
+		dropdown:SetScript("OnHide", nil)
+
+		local left = _G[dropdown:GetName() .. "Left"]
+		local middle = _G[dropdown:GetName() .. "Middle"]
+		local right = _G[dropdown:GetName() .. "Right"]
+
+		middle:ClearAllPoints()
+		right:ClearAllPoints()
+
+		middle:SetPoint("LEFT", left, "RIGHT", 0, 0)
+		middle:SetPoint("RIGHT", right, "LEFT", 0, 0)
+		right:SetPoint("TOPRIGHT", dropdown, "TOPRIGHT", 0, 17)
+
+		local button = _G[dropdown:GetName() .. "Button"]
+		self.button = button
+		button.obj = self
+		button:SetScript("OnEnter", Control_OnEnter)
+		button:SetScript("OnLeave", Control_OnLeave)
+		button:SetScript("OnClick", Dropdown_TogglePullout)
+
+		local button_cover = CreateFrame("BUTTON", nil, self.frame)
+		self.button_cover = button_cover
+		button_cover.obj = self
+		button_cover:SetPoint("TOPLEFT", self.frame, "BOTTOMLEFT", 0, 25)
+		button_cover:SetPoint("BOTTOMRIGHT", self.frame, "BOTTOMRIGHT")
+		button_cover:SetScript("OnEnter", Control_OnEnter)
+		button_cover:SetScript("OnLeave", Control_OnLeave)
+		button_cover:SetScript("OnClick", Dropdown_TogglePullout)
+
+		local text = _G[dropdown:GetName() .. "Text"]
+		self.text = text
+		text.obj = self
+		text:ClearAllPoints()
+		text:SetPoint("RIGHT", right, "RIGHT" ,-43, 2)
+		text:SetPoint("LEFT", left, "LEFT", 25, 2)
+
+		local label = frame:CreateFontString(nil,"OVERLAY","GameFontNormalSmall")
+		label:SetPoint("TOPLEFT", frame, "TOPLEFT", 0, 0)
+		label:SetPoint("TOPRIGHT", frame, "TOPRIGHT", 0, 0)
+		label:SetJustifyH("LEFT")
+		label:SetHeight(18)
+		label:Hide()
+		self.label = label
+
+		AceGUI:RegisterAsWidget(self)
+		return self
+	end
+
+	AceGUI:RegisterWidgetType(widgetType, Constructor, widgetVersion)
+end

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -1044,7 +1044,7 @@ local function populatePrivateAuraOptions(widget)
 			scrollFrame:AddChild(header)
 			for _, option in ipairs(options) do
 				local spellId = option[1]
-				local default = soundModule:GetDefaultSound(option[2]) or soundModule:GetDefaultSound("privateaura")
+				local default = soundModule:GetDefaultSound("privateaura")
 				local key = ("pa_%d"):format(spellId)
 				local id = option.option or spellId
 
@@ -1078,6 +1078,7 @@ local function populatePrivateAuraOptions(widget)
 				dropdown:SetCallback("OnValueChanged", function(widget, _, value)
 					local key = widget:GetUserData("key")
 					local module = widget:GetUserData("module")
+					local default = widget:GetUserData("module")
 					value = soundList[value]
 					if value == default then
 						value = nil

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -1023,7 +1023,7 @@ local function populatePrivateAuraOptions(widget)
 	scrollFrame:PauseLayout()
 
 	local text = AceGUI:Create("Label")
-	text:SetText("Private auras can't be tracked normally, but you can set a sound to be played when you are targeted with the ability.")
+	text:SetText(L.privateAuraSounds_desc)
 	text:SetColor(1, 0.75, 0.79)
 	text:SetImage(icons.PRIVATE)
 	text:SetFullWidth(true)
@@ -1291,7 +1291,7 @@ local function onZoneShow(treeWidget, id)
 		-- Add the private aura plugin module
 		if privateAuraSoundOptions then
 			local moduleName = "Private Aura Sounds"
-			zoneList[moduleName] = "|cffffbfc9Private Aura Sounds|r" -- XXX LOCALIZE
+			zoneList[moduleName] = ("|cffffbfc9%s|r"):format(L.privateAuraSounds)
 			zoneSort[#zoneSort+1] = moduleName
 		end
 	end

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -1066,7 +1066,8 @@ local function populatePrivateAuraOptions(widget)
 
 				local dropdown = AceGUI:Create("SharedDropdown")
 				if option.mythic then
-					dropdown:SetLabel(name .. _G.CreateTextureMarkup(521749, 256, 64, 24, 24, 0.5, 0.625, 0.5, 1)) -- 521749 = Interface\EncounterJournal\UI-EJ-Icons
+					-- dropdown:SetLabel(name .. _G.CreateTextureMarkup(521749, 256, 64, 24, 24, 0.5, 0.625, 0.5, 1)) -- 521749 = Interface\EncounterJournal\UI-EJ-Icons
+					dropdown:SetLabel(name .. "|TInterface\\AddOns\\BigWigs\\Media\\Icons\\Menus\\Mythic:20|t")
 				else
 					dropdown:SetLabel(name)
 				end

--- a/Options/libs.xml
+++ b/Options/libs.xml
@@ -1,6 +1,7 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 ..\FrameXML\UI.xsd">
 <Include file="Libs\AceGUI-3.0\AceGUI-3.0.xml"/>
+<Include file="Libs\AceGUIWidget-SharedDropdown.lua"/>
 <Include file="Libs\AceConfigRegistry-3.0\AceConfigRegistry-3.0.xml"/>
 <Include file="Libs\AceConfigDialog-3.0\AceConfigDialog-3.0.xml"/>
 <Include file="Libs\AceDBOptions-3.0\AceDBOptions-3.0.xml"/>

--- a/Plugins/Locales/deDE.lua
+++ b/Plugins/Locales/deDE.lua
@@ -373,6 +373,7 @@ L.Long = "Lang"
 L.Warning = "Warnung"
 L.onyou = "Ein Zauber, Stärkungs- oder Schwächungszauber ist auf Dir"
 L.underyou = "Du musst aus einem Zauber unter Dir herauslaufen"
+--L.privateaura = "Private aura on you"
 
 L.sound = "Sound"
 

--- a/Plugins/Locales/enUS.lua
+++ b/Plugins/Locales/enUS.lua
@@ -372,6 +372,7 @@ L.Long = "Long"
 L.Warning = "Warning"
 L.onyou = "A spell, buff, or debuff is on you"
 L.underyou = "You need to move out of a spell under you"
+L.privateaura = "Private aura on you"
 
 L.sound = "Sound"
 

--- a/Plugins/Locales/esES.lua
+++ b/Plugins/Locales/esES.lua
@@ -373,6 +373,7 @@ L.Long = "Largo"
 L.Warning = "Advertencia"
 L.onyou = "Un hechizo, beneficio o perjuicio te afecta"
 L.underyou = "Necesitas salir de un hechizo que hay debajo de ti"
+--L.privateaura = "Private aura on you"
 
 L.sound = "Sonido"
 

--- a/Plugins/Locales/esMX.lua
+++ b/Plugins/Locales/esMX.lua
@@ -373,6 +373,7 @@ L.Long = "Largo"
 L.Warning = "Aviso"
 L.onyou = "Una hechizo, efecto o perjuicio está en ti"
 L.underyou = "Debes moverte fuera del hechizo que está debajo de ti"
+--L.privateaura = "Private aura on you"
 
 L.sound = "Sonido"
 

--- a/Plugins/Locales/frFR.lua
+++ b/Plugins/Locales/frFR.lua
@@ -373,6 +373,7 @@ L.Long = "Long"
 L.Warning = "Avertissement"
 L.onyou = "Un sort, amélioration ou affaiblissement est sur vous"
 L.underyou = "Vous devez bouger hors d'un sort qui se trouve en dessous de vous"
+--L.privateaura = "Private aura on you"
 
 L.sound = "Son"
 

--- a/Plugins/Locales/itIT.lua
+++ b/Plugins/Locales/itIT.lua
@@ -373,6 +373,7 @@ L.Long = "Lungo"
 L.Warning = "Avviso"
 L.onyou = "Un'Incantesimo, un potenziamento o un depotenziamento su di te"
 L.underyou = "Devi muoverti fuori dall'incantesimo sotto di te"
+--L.privateaura = "Private aura on you"
 
 L.sound = "Suono"
 

--- a/Plugins/Locales/koKR.lua
+++ b/Plugins/Locales/koKR.lua
@@ -373,6 +373,7 @@ L.Long = "길게"
 L.Warning = "경고"
 L.onyou = "나에게 적용되는 주문, 강화 효과, 약화 효과"
 L.underyou = "내 밑의 \"바닥\"을 피해야 할 때"
+--L.privateaura = "Private aura on you"
 
 L.sound = "소리"
 

--- a/Plugins/Locales/ptBR.lua
+++ b/Plugins/Locales/ptBR.lua
@@ -373,6 +373,7 @@ L.Long = "Longo"
 L.Warning = "Aviso"
 L.onyou = "Um feitiço, buff, ou debuff em você"
 L.underyou = "Você precisa se mover do feitiço embaixo de você"
+--L.privateaura = "Private aura on you"
 
 L.sound = "Som"
 

--- a/Plugins/Locales/ruRU.lua
+++ b/Plugins/Locales/ruRU.lua
@@ -373,6 +373,7 @@ L.Long = "Долгий"
 L.Warning = "Предупреждение"
 L.onyou = "Заклинание, бафф или дебафф на тебе"
 L.underyou = "Тебе нужно выйти из заклинания под ногами"
+--L.privateaura = "Private aura on you"
 
 L.sound = "Звук"
 

--- a/Plugins/Locales/zhCN.lua
+++ b/Plugins/Locales/zhCN.lua
@@ -373,6 +373,7 @@ L.Long = "长响"
 L.Warning = "警报"
 L.onyou = "一个法术，增益或负面效果在你身上"
 L.underyou = "你需要移动，离开你脚下的法术范围"
+--L.privateaura = "Private aura on you"
 
 L.sound = "音效"
 

--- a/Plugins/Locales/zhTW.lua
+++ b/Plugins/Locales/zhTW.lua
@@ -373,6 +373,7 @@ L.Long = "長響"
 L.Warning = "警報"
 L.onyou = "當一個法術或增減益光環施放在你身上時（點名）"
 L.underyou = "當你需要離開一個地板技能的範圍時（跑位）"
+--L.privateaura = "Private aura on you"
 
 L.sound = "音效"
 

--- a/Plugins/Sound.lua
+++ b/Plugins/Sound.lua
@@ -23,6 +23,7 @@ local sounds = {
 	Warning = "BigWigs: Raid Warning",
 	--onyou = BL.spell_on_you,
 	underyou = BL.spell_under_you,
+	privateaura = "BigWigs: Raid Warning",
 }
 
 --------------------------------------------------------------------------------
@@ -38,6 +39,7 @@ plugin.defaultDB = {
 		Warning = sounds.Warning,
 		--onyou = BL.spell_on_you,
 		underyou = BL.spell_under_you,
+		privateaura = sounds.privateaura,
 	},
 	Long = {},
 	Info = {},
@@ -45,6 +47,7 @@ plugin.defaultDB = {
 	Alarm = {},
 	Warning = {},
 	underyou = {},
+	privateaura = {},
 }
 
 plugin.pluginOptions = {
@@ -88,20 +91,28 @@ plugin.pluginOptions = {
 			width = "full",
 			itemControl = "DDI-Sound",
 		},
+		privateaura = {
+			type = "select",
+			name = L.privateaura,
+			order = 4,
+			values = function() return soundList end,
+			width = "full",
+			itemControl = "DDI-Sound",
+		},
 		newline2 = {
 			type = "description",
 			name = "\n\n",
-			order = 3.5,
+			order = 20,
 		},
 		oldSounds = {
 			type = "header",
 			name = L.oldSounds,
-			order = 4,
+			order = 21,
 		},
 		Alarm = {
 			type = "select",
 			name = L.Alarm,
-			order = 5,
+			order = 22,
 			values = function() return soundList end,
 			width = "full",
 			itemControl = "DDI-Sound",
@@ -109,7 +120,7 @@ plugin.pluginOptions = {
 		Alert = {
 			type = "select",
 			name = L.Alert,
-			order = 6,
+			order = 23,
 			values = function() return soundList end,
 			width = "full",
 			itemControl = "DDI-Sound",
@@ -117,7 +128,7 @@ plugin.pluginOptions = {
 		Info = {
 			type = "select",
 			name = L.Info,
-			order = 7,
+			order = 24,
 			values = function() return soundList end,
 			width = "full",
 			itemControl = "DDI-Sound",
@@ -125,7 +136,7 @@ plugin.pluginOptions = {
 		Long = {
 			type = "select",
 			name = L.Long,
-			order = 8,
+			order = 25,
 			values = function() return soundList end,
 			width = "full",
 			itemControl = "DDI-Sound",
@@ -133,7 +144,7 @@ plugin.pluginOptions = {
 		Warning = {
 			type = "select",
 			name = L.Warning,
-			order = 9,
+			order = 26,
 			values = function() return soundList end,
 			width = "full",
 			itemControl = "DDI-Sound",
@@ -148,14 +159,14 @@ plugin.pluginOptions = {
 					plugin.db.profile.media[k] = sounds[k]
 				end
 			end,
-			order = 10,
+			order = 27,
 		},
 		resetAll = {
 			type = "execute",
 			name = L.resetAll,
 			desc = L.resetAllCustomSound,
 			func = function() plugin.db:ResetProfile() end,
-			order = 11,
+			order = 28,
 		},
 	}
 }
@@ -313,6 +324,20 @@ do
 			local path = db.media[newSound] and media:Fetch(SOUND, db.media[newSound], true) or media:Fetch(SOUND, newSound, true)
 			return path
 		end
+	end
+
+	function plugin:GetDefaultSound(soundName)
+		if not soundName then return end
+		if soundName == "none" then
+			return "None"
+		end
+		soundName = tmp[soundName] or soundName
+
+		local custom = soundName:match("^name:(.+)$")
+		if custom and not media:Fetch(SOUND, custom, true) then
+			return
+		end
+		return custom or db.media[soundName]
 	end
 end
 

--- a/embeds.xml
+++ b/embeds.xml
@@ -10,5 +10,7 @@
 <Include file="Libs\LibSharedMedia-3.0\lib.xml"/>
 <Include file="Libs\LibDBIcon-1.0\lib.xml"/>
 @end-non-debug@-->
+<!--@do-not-package@-->
+<Include file="Options\Libs\AceGUIWidget-SharedDropdown.lua"/>
+<!--@end-do-not-package@-->
 </Ui>
-


### PR DESCRIPTION
Setting the private auras in the module is now an API call in the main chunk that passes a table of settings.  Positional arg for aura id, and some named args: `option` to set the tooltip spell id (if the private aura has no description), `mythic` to show the mythic icon next to the name in the spell list, `extra` to provide a table of spell ids if there are multiple used.
  ```lua
mod:SetPrivateAuraSounds({
	420544, -- Scorching Pursuit
	{425888, mythic = true}, -- Igniting Growth
	{407182, option = 407221}, -- Rushing Darkness
	{414186, extra = {414187, 421825, 421826, 421827, 421828, 421829}}, -- Blaze
})
```

- Moves private aura sound settings to an encounter dropdown entry
![Dropdown](https://cdn.discordapp.com/attachments/923446620874473522/1231716470522773574/WowT2_2024-04-21_16-01-37.jpg?ex=66734bda&is=6671fa5a&hm=7a8741cab5cd5b29a6a127004d762c68aef7885463e95e2850a88dcfd9466610&)
![Panel](https://cdn.discordapp.com/attachments/923446620874473522/1231716470833287258/WowT3_2024-04-21_16-21-05.jpg?ex=66734bda&is=6671fa5a&hm=ab18460809be86465a07e889f65a467a6b8848272f84c3f09adae520953157fc&)

- Removes the default `ME_ONLY` and `ME_ONLY_EMPHASIZE` ability options when the `PRIVATE` flag is set
![Ability Settings](https://i.imgur.com/N0b2TmX.jpeg)

- Also adds a new sound category for Private Auras (but not a new sound)
![Sound](https://cdn.discordapp.com/attachments/923446620874473522/1231716470208335962/WowT1_2024-04-21_15-58-44.jpg?ex=66734bda&is=6671fa5a&hm=ccdbcd9fdbac623820e2b86e8f871a7d1aa5ebd66183f107e313f058a53efc48&)