### PR TITLE
Renames

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -218,6 +218,7 @@ globals = {
 	"time",
 	"tinsert",
 	"tremove",
+	"tostringall",
 
 	-- framexml
 	"tContains",

--- a/API.lua
+++ b/API.lua
@@ -158,7 +158,7 @@ do
 	end
 	function API.SetSpellRename(spellId, text)
 		if type(spellId) ~= "number" then error("Invalid spell ID for spell rename.") end
-		if type(text) ~= "string" or #text < 3 then error("Invalid spell text for spell rename.") end
+		if text and type(text) ~= "string" then error("Invalid spell text for spell rename.") end
 		tbl[spellId] = text
 	end
 end

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -316,18 +316,10 @@ function boss:GetAllowWin()
 	return self.allowWin and true or false
 end
 
---- Register private auras.
--- @param opts the options table
 function boss:SetPrivateAuraSounds(opts)
 	for i = 1, #opts do
-		local o = opts[i]
-		if type(o) ~= "table" then
-			opts[i] = { o }
-		elseif o.extra then -- XXX compat
-			for j, v in ipairs(o.extra) do
-				o[j + 1] = v
-			end
-			o.extra = nil
+		if type(opts[i]) ~= "table" then
+			opts[i] = { opts[i] }
 		end
 	end
 	self.privateAuraSoundOptions = opts

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -1330,20 +1330,37 @@ do
 				self.privateAuraSounds = {}
 				local soundModule = plugins.Sounds
 				if soundModule then
-					local default = soundModule:GetDefaultSound("privateaura")
-					for _, opt in next, self.privateAuraSoundOptions do
-						local key = ("pa_%d"):format(opt[1])
+					for _, option in next, self.privateAuraSoundOptions do
+						local spellId = option[1]
+						local default = soundModule:GetDefaultSound("privateaura")
+
+						local key = ("pa_%d"):format(spellId)
 						local sound = soundModule:GetSoundFile(nil, nil, self.db.profile[key] or default)
 						if sound then
-							for i = 1, #opt do
-								local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
-									spellID = opt[i],
-									unitToken = "player",
-									soundFileName = sound,
-									outputChannel = "master",
-								})
-								if privateAuraSoundId then
-									self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
+							local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
+								spellID = spellId,
+								unitToken = "player",
+								soundFileName = sound,
+								outputChannel = "master",
+							})
+							if type(privateAuraSoundId) == "number" then
+								self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
+							else
+								self:Error("Failed to register Private Aura %q with return: %s", spellId, tostring(privateAuraSoundId))
+							end
+							if option.extra then
+								for _, id in next, option.extra do
+									local extrasSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
+										spellID = id,
+										unitToken = "player",
+										soundFileName = sound,
+										outputChannel = "master",
+									})
+									if type(extrasSoundId) == "number" then
+										self.privateAuraSounds[#self.privateAuraSounds + 1] = extrasSoundId
+									else
+										self:Error("Failed to register Private Aura %q with return: %s", id, tostring(extrasSoundId))
+									end
 								end
 							end
 						end

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -3414,7 +3414,14 @@ do
 			if englishSayMessages and englishText then
 				SendChatMessage(format(on, englishText, myName), "SAY")
 			else
-				SendChatMessage(format(L.on, msg and (type(msg) == "number" and spells[msg] or msg) or spells[key], myName), "SAY")
+				-- never use renames for chat messages
+				local text = msg
+				if not text then
+					text = self:SpellName(key, true)
+				elseif type(text) == "number" then
+					text = self:SpellName(text, true)
+				end
+				SendChatMessage(format(L.on, text, myName), "SAY")
 			end
 		end
 		self:Debug(":Say", key, msg, directPrint, englishText)
@@ -3433,7 +3440,14 @@ do
 			if englishSayMessages and englishText then
 				SendChatMessage(format(on, englishText, myName), "YELL")
 			else
-				SendChatMessage(format(L.on, msg and (type(msg) == "number" and spells[msg] or msg) or spells[key], myName), "YELL")
+				-- never use renames for chat messages
+				local text = msg
+				if not text then
+					text = self:SpellName(key, true)
+				elseif type(text) == "number" then
+					text = self:SpellName(text, true)
+				end
+				SendChatMessage(format(L.on, text, myName), "YELL")
 			end
 		end
 		self:Debug(":Yell", key, msg, directPrint, englishText)

--- a/Core/BossPrototype_Classic.lua
+++ b/Core/BossPrototype_Classic.lua
@@ -388,6 +388,8 @@ function boss:GetAllowWin()
 	return self.allowWin and true or false
 end
 
+--- Register private auras.
+-- @param opts the options table
 function boss:SetPrivateAuraSounds(opts)
 	for i = 1, #opts do
 		if type(opts[i]) ~= "table" then
@@ -1394,48 +1396,6 @@ do
 			self.isEngaged = true
 
 			self:Debug(":Engage", "noEngage:", noEngage, self:GetEncounterID(), self.moduleName)
-
-			if self.privateAuraSoundOptions and not self.privateAuraSounds then
-				self.privateAuraSounds = {}
-				local soundModule = plugins.Sounds
-				if soundModule then
-					for _, option in next, self.privateAuraSoundOptions do
-						local spellId = option[1]
-						local default = soundModule:GetDefaultSound("privateaura")
-
-						local key = ("pa_%d"):format(spellId)
-						local sound = soundModule:GetSoundFile(nil, nil, self.db.profile[key] or default)
-						if sound then
-							local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
-								spellID = spellId,
-								unitToken = "player",
-								soundFileName = sound,
-								outputChannel = "master",
-							})
-							if type(privateAuraSoundId) == "number" then
-								self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
-							else
-								self:Error("Failed to register Private Aura %q with return: %s", spellId, tostring(privateAuraSoundId))
-							end
-							if option.extra then
-								for _, id in next, option.extra do
-									local extrasSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
-										spellID = id,
-										unitToken = "player",
-										soundFileName = sound,
-										outputChannel = "master",
-									})
-									if type(extrasSoundId) == "number" then
-										self.privateAuraSounds[#self.privateAuraSounds + 1] = extrasSoundId
-									else
-										self:Error("Failed to register Private Aura %q with return: %s", id, tostring(extrasSoundId))
-									end
-								end
-							end
-						end
-					end
-				end
-			end
 
 			if not noEngage or noEngage ~= "NoEngage" then
 				updateData(self)

--- a/Core/BossPrototype_Classic.lua
+++ b/Core/BossPrototype_Classic.lua
@@ -388,8 +388,6 @@ function boss:GetAllowWin()
 	return self.allowWin and true or false
 end
 
---- Register private auras.
--- @param opts the options table
 function boss:SetPrivateAuraSounds(opts)
 	for i = 1, #opts do
 		if type(opts[i]) ~= "table" then
@@ -1396,6 +1394,48 @@ do
 			self.isEngaged = true
 
 			self:Debug(":Engage", "noEngage:", noEngage, self:GetEncounterID(), self.moduleName)
+
+			if self.privateAuraSoundOptions and not self.privateAuraSounds then
+				self.privateAuraSounds = {}
+				local soundModule = plugins.Sounds
+				if soundModule then
+					for _, option in next, self.privateAuraSoundOptions do
+						local spellId = option[1]
+						local default = soundModule:GetDefaultSound("privateaura")
+
+						local key = ("pa_%d"):format(spellId)
+						local sound = soundModule:GetSoundFile(nil, nil, self.db.profile[key] or default)
+						if sound then
+							local privateAuraSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
+								spellID = spellId,
+								unitToken = "player",
+								soundFileName = sound,
+								outputChannel = "master",
+							})
+							if type(privateAuraSoundId) == "number" then
+								self.privateAuraSounds[#self.privateAuraSounds + 1] = privateAuraSoundId
+							else
+								self:Error("Failed to register Private Aura %q with return: %s", spellId, tostring(privateAuraSoundId))
+							end
+							if option.extra then
+								for _, id in next, option.extra do
+									local extrasSoundId = C_UnitAuras.AddPrivateAuraAppliedSound({
+										spellID = id,
+										unitToken = "player",
+										soundFileName = sound,
+										outputChannel = "master",
+									})
+									if type(extrasSoundId) == "number" then
+										self.privateAuraSounds[#self.privateAuraSounds + 1] = extrasSoundId
+									else
+										self:Error("Failed to register Private Aura %q with return: %s", id, tostring(extrasSoundId))
+									end
+								end
+							end
+						end
+					end
+				end
+			end
 
 			if not noEngage or noEngage ~= "NoEngage" then
 				updateData(self)

--- a/Core/Constants.lua
+++ b/Core/Constants.lua
@@ -196,7 +196,8 @@ function BigWigs:GetBossOptionDetails(module, option)
 		optionType = type(option)
 	end
 
-	local alternativeName = module.altNames and module.altNames[option]
+	local renameModule = self:GetPlugin("Rename", true)
+	local alternativeName = renameModule and renameModule:GetName(module, option) or module.altNames and module.altNames[option]
 	local moduleLocale = module:GetLocale(true)
 
 	if optionType == "string" then

--- a/Core/Constants.lua
+++ b/Core/Constants.lua
@@ -196,8 +196,13 @@ function BigWigs:GetBossOptionDetails(module, option)
 		optionType = type(option)
 	end
 
+	local alternativeName
 	local renameModule = self:GetPlugin("Rename", true)
-	local alternativeName = renameModule and renameModule:GetName(module, option) or module.altNames and module.altNames[option]
+	if renameModule then
+		alternativeName = renameModule:GetName(module, option)
+	else
+		alternativeName = module.altNames and module.altNames[option]
+	end
 	local moduleLocale = module:GetLocale(true)
 
 	if optionType == "string" then

--- a/Core/Core.lua
+++ b/Core/Core.lua
@@ -619,6 +619,24 @@ do
 		end
 		setupOptions(self)
 		self.SetupOptions = nil
+
+		local renameModule = BigWigs:GetPlugin("Rename", true)
+		if renameModule then
+			for _, key in next, self.toggleOptions do
+				if type(key) == "table" then
+					key = key[1]
+				end
+				if type(key) == "number" then
+					self:SetSpellRename(key, renameModule:GetName(self, key))
+				end
+			end
+		elseif self.altNames then -- atleast set static alt names
+			for key, name in next, self.altNames do
+				if type(key) == "number" then
+					self:SetSpellRename(key, name)
+				end
+			end
+		end
 	end
 
 	function core:RegisterBossModule(module)

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -664,47 +664,49 @@ function getAdvancedToggleOption(scrollFrame, dropdown, module, bossOption)
 
 	local renameModule = BigWigs:GetPlugin("Rename", true)
 	if not builtinOptions[dbKey] and renameModule then -- can't rename builtins
-		local customDesc = AceGUI:Create("Label")
-		customDesc:SetText("Set a custom name for the ability. This text will be used instead of the spell name in all messages and bars.")
-		customDesc:SetColor(1, 0.82, 0)
-		customDesc:SetFullWidth(true)
-		widgets[#widgets + 1] = customDesc
+		if type(dbKey) == "number" then -- don't show general rename for string keys
+			local customDesc = AceGUI:Create("Label")
+			customDesc:SetText("Set a custom name for the ability. This text will be used instead of the spell name in all messages and bars.")
+			customDesc:SetColor(1, 0.82, 0)
+			customDesc:SetFullWidth(true)
+			widgets[#widgets + 1] = customDesc
 
-		local default = renameModule:GetDefaultName(module, dbKey)
-		local customName = AceGUI:Create("EditBox")
-		customName:SetText(renameModule:GetName(module, dbKey))
-		customName:SetUserData("key", dbKey)
-		customName:SetUserData("default", default)
-		customName:SetUserData("scrollFrame", scrollFrame)
-		customName:SetUserData("dropdown", dropdown)
-		customName:SetUserData("module", module)
-		customName:SetUserData("option", bossOption)
-		customName:SetCallback("OnEnterPressed", setRenameValue)
-		customName:SetRelativeWidth(0.6)
-		widgets[#widgets + 1] = customName
+			local default = renameModule:GetDefaultName(module, dbKey)
+			local customName = AceGUI:Create("EditBox")
+			customName:SetText(renameModule:GetName(module, dbKey))
+			customName:SetUserData("key", dbKey)
+			customName:SetUserData("default", default)
+			customName:SetUserData("scrollFrame", scrollFrame)
+			customName:SetUserData("dropdown", dropdown)
+			customName:SetUserData("module", module)
+			customName:SetUserData("option", bossOption)
+			customName:SetCallback("OnEnterPressed", setRenameValue)
+			customName:SetRelativeWidth(0.6)
+			widgets[#widgets + 1] = customName
 
-		local customReset = AceGUI:Create("Button")
-		customReset:SetText("Reset")
-		customReset:SetDisabled(not alternativeName or alternativeName == default)
-		customReset:SetUserData("editbox", customName)
-		customReset:SetCallback("OnClick", resetRenameValue)
-		customReset:SetRelativeWidth(0.2)
-		widgets[#widgets + 1] = customReset
+			local customReset = AceGUI:Create("Button")
+			customReset:SetText("Reset")
+			customReset:SetDisabled(not alternativeName or alternativeName == default)
+			customReset:SetUserData("editbox", customName)
+			customReset:SetCallback("OnClick", resetRenameValue)
+			customReset:SetRelativeWidth(0.2)
+			widgets[#widgets + 1] = customReset
 
-		local customDefault = AceGUI:Create("Button")
-		customDefault:SetText("Spell Name")
-		customDefault:SetDisabled(not alternativeName or alternativeName == name or default == module:SpellName(dbKey, true))
-		customDefault:SetUserData("editbox", customName)
-		customDefault:SetUserData("spell", name)
-		customDefault:SetUserData("desc", "This ability has a custom name by default, click this button to use the spell name instead.")
-		customDefault:SetCallback("OnEnter", slaveOptionMouseOver)
-		customDefault:SetCallback("OnLeave", bwTooltip_Hide)
-		customDefault:SetCallback("OnClick", function(widget, event, value)
-			local editbox = widget:GetUserData("editbox")
-			editbox:Fire("OnEnterPressed", widget:GetUserData("spell"))
-		end)
-		customDefault:SetRelativeWidth(0.2)
-		widgets[#widgets + 1] = customDefault
+			local customDefault = AceGUI:Create("Button")
+			customDefault:SetText("Spell Name")
+			customDefault:SetDisabled(not alternativeName or alternativeName == name or default == module:SpellName(dbKey, true))
+			customDefault:SetUserData("editbox", customName)
+			customDefault:SetUserData("spell", name)
+			customDefault:SetUserData("desc", "This ability has a custom name by default, click this button to use the spell name instead.")
+			customDefault:SetCallback("OnEnter", slaveOptionMouseOver)
+			customDefault:SetCallback("OnLeave", bwTooltip_Hide)
+			customDefault:SetCallback("OnClick", function(widget, event, value)
+				local editbox = widget:GetUserData("editbox")
+				editbox:Fire("OnEnterPressed", widget:GetUserData("spell"))
+			end)
+			customDefault:SetRelativeWidth(0.2)
+			widgets[#widgets + 1] = customDefault
+		end
 
 		if module.renameStrings and module.renameStrings[dbKey] then
 			local spacer = AceGUI:Create("Label")

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -916,7 +916,7 @@ local function getDefaultToggleOption(scrollFrame, dropdown, module, bossOption)
 	local flagIcons = {}
 	local showFlags = {
 		"TANK_HEALER", "TANK", "HEALER", "DISPEL",
-		"EMPHASIZE", "ME_ONLY", "ME_ONLY_EMPHASIZE", "CASTBAR", "COUNTDOWN", "CASTBAR_COUNTDOWN", "FLASH", "ICON", "SAY", "SAY_COUNTDOWN",
+		"EMPHASIZE", "ME_ONLY", "ME_ONLY_EMPHASIZE", "COUNTDOWN", "CASTBAR_COUNTDOWN", "FLASH", "ICON", "SAY", "SAY_COUNTDOWN",
 		"PROXIMITY", "INFOBOX", "ALTPOWER", "NAMEPLATE", "PRIVATE",
 	}
 	for i = 1, #showFlags do
@@ -1089,7 +1089,6 @@ local function populatePrivateAuraOptions(widget)
 
 	local privateAuraSoundOptions = widget:GetUserData("privateAuraSoundOptions")
 	local soundList = LibStub("LibSharedMedia-3.0"):List("sound")
-	local defaultSound = soundModule:GetDefaultSound("privateaura")
 	-- preserve module order
 	for _, module in ipairs(widget:GetUserData("moduleList")) do
 		local options = privateAuraSoundOptions[module]
@@ -1102,8 +1101,9 @@ local function populatePrivateAuraOptions(widget)
 			scrollFrame:AddChild(header)
 			for _, option in ipairs(options) do
 				local spellId = option[1]
+				local default = soundModule:GetDefaultSound("privateaura")
 				local key = ("pa_%d"):format(spellId)
-				local id = option.tooltip or option.option or spellId -- XXX compat
+				local id = option.option or spellId
 
 				local name = loader.GetSpellName(id)
 				local texture = loader.GetSpellTexture(id)
@@ -1112,17 +1112,18 @@ local function populatePrivateAuraOptions(widget)
 				icon:SetImage(texture, 0.07, 0.93, 0.07, 0.93)
 				icon:SetImageSize(40, 40)
 				icon:SetRelativeWidth(0.1)
-				icon:SetUserData("spellId", id)
+				icon:SetUserData("bossOption", id)
 				icon:SetUserData("updateTooltip", true)
 				icon:SetCallback("OnEnter", function(widget)
 					bwTooltip:SetOwner(widget.frame, "ANCHOR_RIGHT")
-					bwTooltip:SetSpellByID(widget:GetUserData("spellId"))
+					bwTooltip:SetSpellByID(widget:GetUserData("bossOption"))
 					bwTooltip:Show()
 				end)
 				icon:SetCallback("OnLeave", bwTooltip_Hide)
 
 				local dropdown = AceGUI:Create("SharedDropdown")
 				if option.mythic then
+					-- dropdown:SetLabel(name .. _G.CreateTextureMarkup(521749, 256, 64, 24, 24, 0.5, 0.625, 0.5, 1)) -- 521749 = Interface\EncounterJournal\UI-EJ-Icons
 					dropdown:SetLabel(name .. "|TInterface\\AddOns\\BigWigs\\Media\\Icons\\Menus\\Mythic:20|t")
 				else
 					dropdown:SetLabel(name)
@@ -1130,7 +1131,7 @@ local function populatePrivateAuraOptions(widget)
 				dropdown:SetList(soundList, nil, "DDI-Sound")
 				dropdown:SetRelativeWidth(0.88)
 				dropdown:SetUserData("key", key)
-				dropdown:SetUserData("default", defaultSound)
+				dropdown:SetUserData("default", default)
 				dropdown:SetUserData("module", module)
 				dropdown:SetCallback("OnValueChanged", function(widget, _, value)
 					local key = widget:GetUserData("key")
@@ -1142,7 +1143,7 @@ local function populatePrivateAuraOptions(widget)
 					end
 					module.db.profile[key] = value
 				end)
-				local value = module.db.profile[key] or defaultSound
+				local value = module.db.profile[key] or default
 				for i, v in next, soundList do
 					if v == value then
 						dropdown:SetValue(i)
@@ -1167,7 +1168,7 @@ local function populatePrivateAuraOptions(widget)
 	reset:SetCallback("OnClick", function(widget)
 		for module, options in next, widget:GetUserData("privateAuraSoundOptions") do
 			for _, option in next, options do
-				local key = ("pa_%d"):format(option[1])
+				local key = "pa_" .. option[1]
 				module.db.profile[key] = nil
 			end
 		end

--- a/Plugins/Rename.lua
+++ b/Plugins/Rename.lua
@@ -2,7 +2,11 @@
 -- Module Declaration
 --
 
-local plugin = BigWigs:NewPlugin("Rename")
+local plugin, CL = BigWigs:NewPlugin("Rename", {
+	"GetDefaultName",
+	"GetName",
+	"SetName",
+})
 if not plugin then return end
 
 --------------------------------------------------------------------------------
@@ -21,7 +25,8 @@ function plugin:GetDefaultName(module, key)
 		BigWigs:Error(("Rename: Missing module or key (%q, %q)"):format(tostringall(module, key)))
 		return
 	end
-	return module.altNames and module.altNames[key] or module:SpellName(key, true)
+	local altName = module.altNames and module.altNames[key]
+	return altName or module:SpellName(key, true)
 end
 
 function plugin:GetName(module, key)
@@ -31,7 +36,7 @@ function plugin:GetName(module, key)
 		return
 	end
 	local altName = module.altNames and module.altNames[key]
-	local moduleDb = self.db.profile[module.name]
+	local moduleDb = plugin.db.profile[module.name]
 	return moduleDb and moduleDb[key] or altName
 end
 
@@ -45,9 +50,9 @@ function plugin:SetName(module, key, value)
 		value = nil
 	end
 	local moduleName = module.name
-	if value and not self.db.profile[moduleName] then
-		self.db.profile[moduleName] = {}
+	if value and not plugin.db.profile[moduleName] then
+		plugin.db.profile[moduleName] = {}
 	end
-	self.db.profile[moduleName][key] = value
+	plugin.db.profile[moduleName][key] = value
 	module:SetSpellRename(key, value)
 end

--- a/Plugins/Rename.lua
+++ b/Plugins/Rename.lua
@@ -1,0 +1,53 @@
+-------------------------------------------------------------------------------
+-- Module Declaration
+--
+
+local plugin = BigWigs:NewPlugin("Rename")
+if not plugin then return end
+
+--------------------------------------------------------------------------------
+-- Options
+--
+
+plugin.defaultDB = {}
+
+--------------------------------------------------------------------------------
+-- API
+--
+
+function plugin:GetDefaultName(module, key)
+	if type(module) == "string" then module = BigWigs:GetBossModule(module, true) end
+	if not module or not key then
+		BigWigs:Error(("Rename: Missing module or key (%q, %q)"):format(tostringall(module, key)))
+		return
+	end
+	return module.altNames and module.altNames[key] or module:SpellName(key, true)
+end
+
+function plugin:GetName(module, key)
+	if type(module) == "string" then module = BigWigs:GetBossModule(module, true) end
+	if not module or not key then
+		BigWigs:Error(("Rename: Missing module or key (%q, %q)"):format(tostringall(module, key)))
+		return
+	end
+	local altName = module.altNames and module.altNames[key]
+	local moduleDb = self.db.profile[module.name]
+	return moduleDb and moduleDb[key] or altName
+end
+
+function plugin:SetName(module, key, value)
+	if type(module) == "string" then module = BigWigs:GetBossModule(module, true) end
+	if not module or not key then
+		BigWigs:Error(("Rename: Missing module or key (%q, %q)"):format(tostringall(module, key)))
+		return
+	end
+	if value == "" then
+		value = nil
+	end
+	local moduleName = module.name
+	if value and not self.db.profile[moduleName] then
+		self.db.profile[moduleName] = {}
+	end
+	self.db.profile[moduleName][key] = value
+	module:SetSpellRename(key, value)
+end

--- a/Plugins/Rename.lua
+++ b/Plugins/Rename.lua
@@ -26,6 +26,7 @@ function plugin:GetDefaultName(module, key)
 		return
 	end
 	local altName = module.altNames and module.altNames[key]
+	if altName == CL.mythic then altName = nil end -- XXX using altnames as labels/descriptors z.z
 	return altName or module:SpellName(key, true)
 end
 
@@ -36,6 +37,7 @@ function plugin:GetName(module, key)
 		return
 	end
 	local altName = module.altNames and module.altNames[key]
+	if altName == CL.mythic then altName = nil end
 	local moduleDb = plugin.db.profile[module.name]
 	return moduleDb and moduleDb[key] or altName
 end

--- a/Plugins/modules.xml
+++ b/Plugins/modules.xml
@@ -22,4 +22,6 @@
 <Script file="Victory.lua"/>
 <Script file="Wipe.lua"/>
 
+<Script file="Rename.lua"/>
+
 </Ui>


### PR DESCRIPTION
Adds the option to rename spells in the options.  Renames are done using `:SetSpellRename` to set the value in the `spells` table, then the renaming happens in the CLEU handler. The module doesn't have to do anything special, ie, `args.spellName` will be the renamed text.  This also means `:SpellName` returns the renamed value, with a new optional second arg  (`:SpellName(id, true)`) to return the value from GetSpellInfo/EJ_GetSectionInfo directly. 

The rename values are stored in a new `Rename` plugin with a simple getter/setter. Initial setup is done in the module's `:SetupOptions`, so on module enable or when opening the config. Setting a value in the Rename plugin will run `:SetSpellRename` in the associated module to handle user updates in the config.

Preset renames are set using the altNames table in `:GetOptions`. This can be the current `[spellId] = L.string` mapping or an indexed table for additional settings. The first table entry is always the rename string. Any tables entries that are a number will be treated as spell ids that should also get the same rename string. Any table entries that are a string will be treated as a key in the locale table to be overwritten with the rename string.

Example: TheBloodboundHorror.lua
```lua
local L = mod:GetLocale()
if L then
	L.bloodcurdle = "Spreads"
	L.bloodcurdle_singular = "Spread"
end

function mod:GetOptions()
	return {
		-- options
	},{
		-- headers
	},{
		-- altNames
		[452237] = {L.bloodcurdle, "bloodcurdle_singular"}, -- Bloodcurdle (Spreads)
	}
end
```

This results in `:Log` callbacks for spell id 452237 having `args.spellName` renamed to the value in `L.bloodcurdle` and any call to `:SpellName(452237)` returning the renamed value. In the options this will show up like it does currently with the name in parentheses next to the spell name.  Including the `bloodcurdle_singular` locale key will also add that value to config as something you can rename.  This is indicated in the config by including a "+X" value next to or inplace of the rename value to indicate there are additional strings you can rename.  The locale table entry gets overwritten by the user-set value, so any usage of `L.bloodcurdle_singular` will reflect the user value.

![image](https://github.com/user-attachments/assets/c52ae51b-956e-4060-af45-a0ec33715ca0)

Ability options:
![image](https://github.com/user-attachments/assets/db545de9-39ed-480f-8ca5-c565147e0696)

The `Reset` button enables when the text isn't the default (module preset value or empty) and the `Spell Name` button enables when there is a module preset value to easily rename it back to the actual spell name. The `Spell Name` button is always there to keep the layout code simple, but it should probably not show if there isn't a module preset rename.

How the title of the locale strings shows in the config is unfinished. Right now it just title cases the string without underscores, but my idea was to use suffixes to show a localized generic title, ie, `_singular` -> "Singular Form (Target Message/Bar)".

Since this is all driven from the current altNames table, we'd need to rework how to show "labels" in the config, as LittleWigs uses the altName to show mythic only spells and such.  An idea is to add a flag to the ability options like "MYTHIC" (that isn't an actual bit flag) to show the difficulty icon, and/or add a helper function to prepend the blue text "label" to the description text.