### PR TITLE
Implement PlayerRenames

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -157,6 +157,33 @@ do
 	end
 end
 
+
+--------------------------------------------------------------------------------
+-- Player renames
+--
+
+do
+	local tbl = {}
+
+	-- This function provides external addons with the player renames that we use in our modules
+	-- @param name string
+	-- @param string
+	function API.GetPlayerRename(name)
+		return tbl[name]
+	end
+
+	-- Set the name of a player
+	-- @param name string
+	-- @param string
+	function API.SetPlayerRename(old_name, new_name)
+		if type(old_name) ~= "string" or #old_name < 3 then error("Invalid old name for player rename.") end
+		if type(new_name) ~= "string" or #new_name < 3 then error("Invalid new name for player rename.") end
+		tbl[old_name] = new_name
+	end
+end
+
+
+
 --------------------------------------------------------------------------------
 -- Versions
 --

--- a/API.lua
+++ b/API.lua
@@ -165,16 +165,16 @@ end
 do
 	local tbl = {}
 
-	-- This function provides external addons with the player renames that we use in our modules
+	-- This function player renames that we use in our modules
 	-- @param name string
-	-- @param string
+	-- @return string?
 	function API.GetPlayerRename(name)
 		return tbl[name]
 	end
 
-	-- Set the name of a player
-	-- @param name string
-	-- @param string
+	-- Set the a new name for a player
+	-- @param old_name string
+	-- @param new_name string
 	function API.SetPlayerRename(old_name, new_name)
 		if type(old_name) ~= "string" or #old_name < 3 then error("Invalid old name for player rename.") end
 		if type(new_name) ~= "string" or #new_name < 3 then error("Invalid new name for player rename.") end

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -53,7 +53,7 @@ local PlaySoundFile = loader.PlaySoundFile
 local C = core.C
 local myName = loader.UnitName("player")
 local myNameWithColor
-local myNickname
+local myNameRenamed
 local myLocale = GetLocale()
 local hasVoice = BigWigsAPI:HasVoicePack()
 local bossUtilityFrame = CreateFrame("Frame")
@@ -106,7 +106,7 @@ local updateData = function(module)
 		englishSayMessages = false
 	end
 
-	myNickname = core.db.profile.nickname or myName
+	myNameRenamed = BigWigsAPI.GetPlayerRename(myName) or myName
 
 	if LibSpec then
 		local _, role, position = LibSpec:MySpecialization()
@@ -1534,6 +1534,7 @@ do
 		function(self, key)
 			if key then
 				local shortKey = gsub(key, "%-.+", "*") -- Replace server names with *
+				shortKey = BigWigsAPI.GetPlayerRename(key) or shortKey
 				local _, class = UnitClass(key)
 				if class then
 					local newKey = hexColors[class] .. shortKey .. "|r"
@@ -1580,11 +1581,11 @@ do
 			if type(player) == "table" then
 				local tmp = {}
 				for i = 1, #player do
-					tmp[i] = gsub(player[i], "%-.+", "*") -- Replace server names with *
+					tmp[i] = BigWigsAPI.GetPlayerRename(player[i]) or gsub(player[i], "%-.+", "*") -- Replace server names with *
 				end
 				return tmp
 			else
-				return gsub(player, "%-.+", "*") -- Replace server names with *
+				return BigWigsAPI.GetPlayerRename(player) or gsub(player, "%-.+", "*") -- Replace server names with *
 			end
 		end
 	end
@@ -3415,9 +3416,9 @@ do
 			SendChatMessage(englishSayMessages and englishText or msg, "SAY")
 		else
 			if englishSayMessages and englishText then
-				SendChatMessage(format(on, englishText, myNickname), "SAY")
+				SendChatMessage(format(on, englishText, myNameRenamed), "SAY")
 			else
-				SendChatMessage(format(L.on, msg and (type(msg) == "number" and spells[msg] or msg) or spells[key], myNickname), "SAY")
+				SendChatMessage(format(L.on, msg and (type(msg) == "number" and spells[msg] or msg) or spells[key], myNameRenamed), "SAY")
 			end
 		end
 		self:Debug(":Say", key, msg, directPrint, englishText)
@@ -3434,9 +3435,9 @@ do
 			SendChatMessage(englishSayMessages and englishText or msg, "YELL")
 		else
 			if englishSayMessages and englishText then
-				SendChatMessage(format(on, englishText, myNickname), "YELL")
+				SendChatMessage(format(on, englishText, myNameRenamed), "YELL")
 			else
-				SendChatMessage(format(L.on, msg and (type(msg) == "number" and spells[msg] or msg) or spells[key], myNickname), "YELL")
+				SendChatMessage(format(L.on, msg and (type(msg) == "number" and spells[msg] or msg) or spells[key], myNameRenamed), "YELL")
 			end
 		end
 		self:Debug(":Yell", key, msg, directPrint, englishText)

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -1533,8 +1533,7 @@ do
 	local coloredNames = setmetatable({}, {__index =
 		function(self, key)
 			if key then
-				local shortKey = gsub(key, "%-.+", "*") -- Replace server names with *
-				shortKey = BigWigsAPI.GetPlayerRename(key) or shortKey
+				local shortKey = BigWigsAPI.GetPlayerRename(key) or gsub(key, "%-.+", "*") -- Replace server names with *
 				local _, class = UnitClass(key)
 				if class then
 					local newKey = hexColors[class] .. shortKey .. "|r"

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -53,6 +53,7 @@ local PlaySoundFile = loader.PlaySoundFile
 local C = core.C
 local myName = loader.UnitName("player")
 local myNameWithColor
+local myNickname
 local myLocale = GetLocale()
 local hasVoice = BigWigsAPI:HasVoicePack()
 local bossUtilityFrame = CreateFrame("Frame")
@@ -104,6 +105,8 @@ local updateData = function(module)
 	else
 		englishSayMessages = false
 	end
+
+	myNickname = core.db.profile.nickname or myName
 
 	if LibSpec then
 		local _, role, position = LibSpec:MySpecialization()
@@ -3412,9 +3415,9 @@ do
 			SendChatMessage(englishSayMessages and englishText or msg, "SAY")
 		else
 			if englishSayMessages and englishText then
-				SendChatMessage(format(on, englishText, myName), "SAY")
+				SendChatMessage(format(on, englishText, myNickname), "SAY")
 			else
-				SendChatMessage(format(L.on, msg and (type(msg) == "number" and spells[msg] or msg) or spells[key], myName), "SAY")
+				SendChatMessage(format(L.on, msg and (type(msg) == "number" and spells[msg] or msg) or spells[key], myNickname), "SAY")
 			end
 		end
 		self:Debug(":Say", key, msg, directPrint, englishText)
@@ -3431,9 +3434,9 @@ do
 			SendChatMessage(englishSayMessages and englishText or msg, "YELL")
 		else
 			if englishSayMessages and englishText then
-				SendChatMessage(format(on, englishText, myName), "YELL")
+				SendChatMessage(format(on, englishText, myNickname), "YELL")
 			else
-				SendChatMessage(format(L.on, msg and (type(msg) == "number" and spells[msg] or msg) or spells[key], myName), "YELL")
+				SendChatMessage(format(L.on, msg and (type(msg) == "number" and spells[msg] or msg) or spells[key], myNickname), "YELL")
 			end
 		end
 		self:Debug(":Yell", key, msg, directPrint, englishText)


### PR DESCRIPTION
This adds two API Functions to allow other addons to set nicknames for players.

With Nickname Addons becomming more and more popular recently I belive it would be a good addition to be able to apply custom names in BigWigs.
This would help consitency within the UIs.

Test code:
```lua
BigWigsAPI.SetPlayerRename(GetUnitName("player", true), "John")
BigWigsAPI.SetPlayerRename(GetUnitName("party1", true), "Fred")
```

on the `player`
![image](https://github.com/user-attachments/assets/62784b05-3d00-4e78-9ba0-3f5791606837)

on a party member:
![image](https://github.com/user-attachments/assets/e363a8dd-39f8-49c0-acd9-aa1af65526aa)


the implementation is not ideal.
`coloredNames` caches the formatted names. If a player updates their nicknames it would not be reflected.

