### PR TITLE
Correct API.RegisterProfile to prevent false positives by verifying source of the call

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -132,7 +132,7 @@ do
 	-- When specified, a callback function will be called with a boolean as the first arg. True if the user accepted, false otherwise
 	local IsAddOnLoaded = C_AddOns.IsAddOnLoaded
 	function API.RegisterProfile(addonName, profileString, optionalCustomProfileName, optionalCallbackFunction)
-		if optionalCustomProfileName == "QuaziiUI" or IsAddOnLoaded("QuaziiUI") then error("This profile is blocked from being imported until it stops tampering with BigWigs bitflag options.") end
+		if optionalCustomProfileName == "QuaziiUI" or debugstack():find("[\\/]QuaziiUI[\\/]") then error("This profile is blocked from being imported until it stops tampering with BigWigs bitflag options.") end
 		if type(addonName) ~= "string" or #addonName < 3 then error("Invalid addon name for profile import.") end
 		if type(profileString) ~= "string" or #profileString < 3 then error("Invalid profile string for profile import.") end
 		if optionalCustomProfileName and (type(optionalCustomProfileName) ~= "string" or #optionalCustomProfileName < 3) then error("Invalid custom profile name for the string you want to import.") end


### PR DESCRIPTION
Change Addon check in API to prevent false positives to other installers not related to the blocked installer by verifying what addon is the import source and only blocking the addon in question