### PR TITLE
Pass pull slash command input through SecureCmdOptionParse

### DIFF
--- a/Plugins/Pull.lua
+++ b/Plugins/Pull.lua
@@ -391,10 +391,12 @@ BigWigsAPI.RegisterSlashCommand("/pull", function(input)
 
 	if not IsInGroup() or (IsInGroup(2) and UnitGroupRolesAssigned("player") == "TANK") or UnitIsGroupLeader("player") or UnitIsGroupAssistant("player") or (IsInGroup(1) and not IsInRaid()) then -- Solo, tank in LFG, leader, assist, anyone in 5m
 		if not plugin:IsEnabled() then BigWigs:Enable() end
-		if input == "" then
+
+		local pullTime = SecureCmdOptionParse(input)
+		if pullTime == "" then
 			DoCountdown(10) -- Allow typing /pull to start a 10 second pull timer
 		else
-			local seconds = tonumber(input)
+			local seconds = tonumber(pullTime)
 			if not seconds or seconds < 0 or seconds > 86400 then BigWigs:Print(L.wrongPullFormat) return end
 			if seconds ~= 0 then
 				BigWigs:Print(L.sendPull)


### PR DESCRIPTION
On a regular occurrence, my raid leader will, after starting a pull timer, yell "Dont pull dont pull". On a rare occasion someone will mention typing `/pull 0` will cancel the timer. But after he mention he uses a macro, I got to wondering if it would be possible to have said macro also cancel the timer on right click, but looking at code it was not possible.

This change will pass the input of the `/pull` slash command through `SecureCmdOptionParse` function.

Not only will this allow people to stop a pull with a right click `/pull [btn:2]0; 10`, but maybe have different timers for a party vs raid `[party]10; [raid]30;` or even different raid sizes `/pull [@raid30]15; [@raid15]30`