### PR TITLE
Make chat messages optional

### DIFF
--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -68,6 +68,7 @@ local myGroupGUIDs, myGroupRoles, myGroupRolePositions = {}, {}, {}
 local solo = false
 local classColorMessages = true
 local englishSayMessages = false
+local enableSayMessages = true
 do -- Update some data that may be called at the top of modules (prior to initialization)
 	local _, _, diff, _, currentMaxPlayers = GetInstanceInfo()
 	difficulty, maxPlayers = diff, currentMaxPlayers
@@ -101,6 +102,12 @@ local updateData = function(module)
 		englishSayMessages = true
 	else
 		englishSayMessages = false
+	end
+
+	if loader.db.profile.enableSayMessages then
+		enableSayMessages = true
+	else
+		enableSayMessages = false
 	end
 
 	local _, _, diff = GetInstanceInfo()
@@ -3550,6 +3557,7 @@ do
 	-- @bool[opt] directPrint if true, skip formatting the message and print the string directly to chat.
 	-- @string[opt] englishText The text string to replace the message with if the user has enabled the option to only print messages in English
 	function boss:Say(key, msg, directPrint, englishText)
+		if not enableSayMessages then return end
 		if not checkFlag(self, key, C.SAY) then return end
 		if directPrint then
 			SendChatMessage(englishSayMessages and englishText or msg, "SAY")
@@ -3569,6 +3577,7 @@ do
 	-- @bool[opt] directPrint if true, skip formatting the message and print the string directly to chat.
 	-- @string[opt] englishText The text string to replace the message with if the user has enabled the option to only print messages in English
 	function boss:Yell(key, msg, directPrint, englishText)
+		if not enableSayMessages then return end
 		if not checkFlag(self, key, C.SAY) then return end
 		if directPrint then
 			SendChatMessage(englishSayMessages and englishText or msg, "YELL")
@@ -3614,6 +3623,7 @@ do
 	-- @number[opt] startAt When to start sending messages in say, default value is at 3 seconds remaining
 	-- @string[opt] englishText The text string to replace the message with if the user has enabled the option to only print messages in English
 	function boss:SayCountdown(key, seconds, textOrIcon, startAt, englishText)
+		if not enableSayMessages then return end
 		if not checkFlag(self, key, C.SAY_COUNTDOWN) then return end
 		local start = startAt or 3
 		local tbl = {false}
@@ -3638,6 +3648,7 @@ do
 	-- @number[opt] startAt When to start sending messages in yell, default value is at 3 seconds remaining
 	-- @string[opt] englishText The text string to replace the message with if the user has enabled the option to only print messages in English
 	function boss:YellCountdown(key, seconds, textOrIcon, startAt, englishText)
+		if not enableSayMessages then return end
 		if not checkFlag(self, key, C.SAY_COUNTDOWN) then return end
 		local start = startAt or 3
 		local tbl = {false}

--- a/Loader.lua
+++ b/Loader.lua
@@ -1128,6 +1128,7 @@ if not public.isVanilla then -- XXX Support for LoadSavedVariablesFirst [Mainlin
 			showZoneMessages = true,
 			fakeDBMVersion = false,
 			englishSayMessages = false,
+			enableSayMessages = true,
 		},
 		global = {
 			watchedMovies = {},

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -111,6 +111,8 @@ L.dbmFaker = "Pretend I'm using DBM"
 L.dbmFakerDesc = "If a DBM user does a version check to see who's using DBM, they will see you on the list. Useful for guilds that force using DBM."
 L.zoneMessages = "Show zone messages"
 L.zoneMessagesDesc = "Disabling this will stop showing messages when you enter a zone that BigWigs has timers for, but you don't have installed. We recommend you leave this turned on as it's the only notification you will get if we suddenly create timers for a new zone that you find useful."
+L.enableSayMessages = "Enable say messages"
+L.enableSayMessagesDesc = "Enable 'say' and 'yell' messages during a boss encounter."
 L.englishSayMessages = "English-only say messages"
 L.englishSayMessagesDesc = "All the 'say' and 'yell' messages that you send in chat during a boss encounter will always be in English. Can be useful if you are with a mixed language group of players."
 

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -148,11 +148,18 @@ local acOptions = {
 					order = 40,
 					width = "full",
 				},
+				enableSayMessages = {
+					type = "toggle",
+					name = L.enableSayMessages,
+					desc = L.enableSayMessagesDesc,
+					order = 41,
+					width = "full",
+				},
 				englishSayMessages = {
 					type = "toggle",
 					name = L.englishSayMessages,
 					desc = L.englishSayMessagesDesc,
-					order = 41,
+					order = 42,
 					width = "full",
 					disabled = function()
 						local myLocale = GetLocale()


### PR DESCRIPTION
When combining BigWigs with other encounter-addons (such as BigWigs WeakAuras packs from RWF guilds) there is often a marking mismatch (i.e. BigWigs will `/say` a blue marker while the WeakAura will assign a yellow marker). This patch simply adds the option to opt-out of chat messages in BigWigs.

I attached this new option to both the say and countdown methods, but it would probably be best if there was a dedicated marking method and split this into 3 options (one for countdown, one for marking, and one for anything else).

I have not provided translations for the strings, and you might want to put a warning on this option (like with statistics).