### PR TITLE
Tools/Keystones: Fix date display in History tab

### DIFF
--- a/Tools/Keystones.lua
+++ b/Tools/Keystones.lua
@@ -1378,9 +1378,9 @@ do
 			local challengeMapName, _, timeLimit = GetMapUIInfo(runs[i].mapChallengeModeID)
 			cellDate:SetWidth(WIDTH_RATING+13)
 			local dateTbl = runs[i].completionDate
+			cellDate.text:SetText(L.dayNamesShort[dateTbl.weekday + 1] or L.dayNamesShort[dateTbl.weekday] or "?")
 			local dayNameStr = L.dayNames[dateTbl.weekday + 1] or L.dayNames[dateTbl.weekday] or "?"
 			local monthStr = L.monthNames[dateTbl.month + 1] or L.monthNames[dateTbl.month] or "?"
-			cellDate.text:SetText(L.dayNamesShort[dateTbl.weekday + 1] or L.dayNamesShort[dateTbl.weekday] or "?")
 			cellDate.tooltip = L.dateFormat:format(dayNameStr, dateTbl.day+1, monthStr, dateTbl.year+2000)
 			cellMapName:SetWidth(WIDTH_MAP)
 			cellMapName.text:SetText(dungeonNamesTiny[runs[i].mapChallengeModeID] or runs[i].mapChallengeModeID)


### PR DESCRIPTION
```Lua
1x BigWigs/Tools/Keystones.lua:1382: bad argument #3 to 'format' (string expected, got nil)
[BigWigs/Tools/Keystones.lua]:1382: in function <BigWigs/Tools/Keystones.lua:1269>
```

Summary of what was implemented:
- After `local dateTbl = runs[i].completionDate` added safe lookups:
  - `dayNameStr` = `L.dayNames[dateTbl.weekday + 1] or L.dayNames[dateTbl.weekday] or "?"`
  - `monthStr` = `L.monthNames[dateTbl.month + 1] or L.monthNames[dateTbl.month] or "?"`
- Replaced the date tooltip with:  
  `cellDate.tooltip = L.dateFormat:format(dayNameStr, dateTbl.day+1, monthStr, dateTbl.year+2000)`  
  so `format()` never gets nil for month or weekday.
- Made the date cell text safe as well:  
  `cellDate.text:SetText(L.dayNamesShort[dateTbl.weekday + 1] or L.dayNamesShort[dateTbl.weekday] or "?")`  
  so a 0-based `weekday` doesn’t cause a nil there either.
  
  
  `/key` now works without errors.
  
  
<img width="386" height="653" alt="image" src="https://github.com/user-attachments/assets/ccb06430-8db6-4c33-99e5-dfe26951e4d5" />
