### PR TITLE
MarchOnQuelDanas/MidnightFalls: Fix Dark Meltdown spell ID

### DIFF
--- a/MarchOnQuelDanas/MidnightFalls.lua
+++ b/MarchOnQuelDanas/MidnightFalls.lua
@@ -687,7 +687,7 @@ function mod:DarkMeltdown(duration)
 			self:Message("stages", "cyan", CL.stage:format(3), false)
 			self:PlaySound("stages", "long")
 
-			self:Bar(1279420, 8, self:GetName(1279420)) -- Dark Meltdown
+			self:Bar(1281194, 8, self:GetName(1281194)) -- Dark Meltdown
 		end
 	}
 end


### PR DESCRIPTION
Spell ID is for quasar, so currently getting a random beam bar at the end of P2