### PR TITLE
Renames

### DIFF
--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -518,6 +518,23 @@ do
 	end
 end
 
+--- Set spell renames.
+-- @param renameOptionTable the options table
+function boss:SetRenames(renameOptionTable)
+	for key, strings in next, renameOptionTable do
+		if type(strings) ~= "table" then
+			strings = {strings}
+			renameOptionTable[key] = strings
+		end
+		for _, replacementKey in ipairs(strings) do
+			if not self.localization[replacementKey] and not CL[replacementKey] then
+				core:Error(("Module %q tried to set invalid rename string %q for id %q."):format(self.moduleName, replacementKey, key))
+			end
+		end
+	end
+	self.renameOptions = renameOptionTable
+end
+
 --- Check if a module option is enabled.
 -- This is a wrapper around the self.db.profile[key] table.
 -- @return boolean or number, depending on option type
@@ -632,7 +649,31 @@ do
 	end
 end
 
-function boss:Initialize() core:RegisterBossModule(self.moduleName) end
+function boss:Initialize()
+	core:RegisterBossModule(self.moduleName)
+
+	-- XXX really only need to do this once and it has to be a closure to use the module ref
+	self.renameSpells = setmetatable({}, { __index =
+		function(tbl, key)
+			local value = plugins.Rename:GetName(self, key)
+			if not value then
+				if type(key) == "number" then
+					value = spells[key]
+					-- error handled in spells
+				else
+					value = self.localization[key]
+					if not value then
+						value = "INVALID"
+						core:Print(format("An invalid locale string (%s) is being used in a boss module.", key))
+					end
+				end
+			end
+			tbl[key] = value
+			return value
+		end
+	})
+end
+
 function boss:Enable(isWipe)
 	if not self:IsEnabled() then
 		self.enabled = true
@@ -748,6 +789,8 @@ function boss:Disable(isWipe)
 		self.isWinning = nil
 		self.bossTargetChecks = nil
 		self.stageTime = nil
+
+		twipe(self.renameSpells) -- Wipe rename cache
 
 		if not isWiping then
 			self:SendMessage("BigWigs_OnBossDisable", self)
@@ -2008,6 +2051,12 @@ function boss:MobId(guid)
 	if not guid then return 1 end
 	local _, _, _, _, _, id = strsplit("-", guid)
 	return tonumber(id) or 1
+end
+
+--- Get the display name of a spell.
+-- @param key the option key or localized string key
+function boss:GetName(key)
+	return self.renameSpells[key]
 end
 
 --- Get a localized spell name from an id. Positive ids for spells (C_Spell.GetSpellName) and negative ids for journal-based section entries (C_EncounterJournal.GetSectionInfo).

--- a/Core/Constants.lua
+++ b/Core/Constants.lua
@@ -1,9 +1,12 @@
 
 local BigWigs = {}
+
+local plugins
 do
 	local _, tbl =...
 	tbl.core = BigWigs
 	tbl.plugins = {}
+	plugins = tbl.plugins
 end
 
 local C = {}
@@ -113,6 +116,10 @@ local customBossOptions = { -- Adding core generic toggles
 	energy = {L.energy, L.energy_desc, false},
 }
 
+function BigWigs:IsCustomBossOption(key)
+	return customBossOptions[key] and true
+end
+
 local function getIcon(icon, module, option)
 	if type(icon) == "number" then
 		if icon > 8 then
@@ -147,6 +154,8 @@ function BigWigs:GetBossOptionDetails(module, option)
 	end
 
 	local optionNotes = module.notes and module.notes[option]
+	local optionRename = plugins.Rename and plugins.Rename:GetName(module, option)
+
 	local moduleLocale = module:GetLocale(true)
 
 	if optionType == "string" then
@@ -181,7 +190,7 @@ function BigWigs:GetBossOptionDetails(module, option)
 
 		local icon = getIcon(moduleLocale[option .. "_icon"], module, option)
 
-		return option, title, description, icon, optionNotes
+		return option, title, description, icon, optionNotes, optionRename
 	elseif optionType == "number" then
 		if option > 0 then
 			local spellName = GetSpellName(option)
@@ -213,7 +222,7 @@ function BigWigs:GetBossOptionDetails(module, option)
 				icon = getIcon(iconReplacement, module, option)
 			end
 			local roleDesc = getRoleStrings(module, option)
-			return option, spellName, roleDesc..desc, icon, optionNotes
+			return option, spellName, roleDesc..desc, icon, optionNotes, optionRename
 		else
 			-- This is an EncounterJournal ID
 			local tbl = C_EncounterJournal_GetSectionInfo(-option)
@@ -227,7 +236,7 @@ function BigWigs:GetBossOptionDetails(module, option)
 			end
 
 			local roleDesc = getRoleStrings(module, option)
-			return option, title, roleDesc..description, abilityIcon or false, optionNotes
+			return option, title, roleDesc..description, abilityIcon or false, optionNotes, optionRename
 		end
 	end
 end

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -60,7 +60,7 @@ L.outOfDateAddOnPopup = "The |cFF436EEE%s|r addon is out of date!"
 L.outOfDateAddOnRaidWarning = "The |cFF436EEE%s|r addon is out of date! You have v%d.%d.%d but the latest is v%d.%d.%d!"
 L.disabledAddOn = "You have the |cFF436EEE%s|r addon disabled, timers will not be shown."
 L.removeAddOn = "Please remove '|cFF436EEE%s|r' as it's been replaced by '|cFF436EEE%s|r'."
-L.alternativeName = "%s (|cFF436EEE%s|r)"
+L.noteLabel = "%s (|cFF436EEE%s|r)"
 L.outOfDateContentPopup = "WARNING!\nYou updated |cFF436EEE%s|r but you also need to update the main |cFF436EEEBigWigs|r addon.\nIgnoring this will result in broken functionality."
 L.outOfDateContentRaidWarning = "|cFF436EEE%s|r requires version %d of the main |cFF436EEEBigWigs|r addon to function correctly, but you're on version %d."
 L.addOnLoadFailedWithReason = "BigWigs failed to load the addon |cFF436EEE%s|r with reason %q. Tell the BigWigs devs!"
@@ -1143,6 +1143,15 @@ L.primary = "Primary"
 L.primaryDesc = "The first raid target icon that a encounter script should use."
 L.secondary = "Secondary"
 L.secondaryDesc = "The second raid target icon that a encounter script should use."
+
+-----------------------------------------------------------------------
+-- Rename.lua
+--
+
+L.renameLabel = "%s (|cFFFFFF99%s|r)"
+L.renameHeader = "Set a custom name for the ability. This text will be used instead of the spell name in all messages and bars."
+L.spellName = "Spell Name"
+L.spellNameResetDesc = "This ability has a custom name by default, click this button to use the spell name instead."
 
 -----------------------------------------------------------------------
 -- Sound.lua

--- a/MarchOnQuelDanas/MidnightFalls.lua
+++ b/MarchOnQuelDanas/MidnightFalls.lua
@@ -74,11 +74,10 @@ if L then
 	L.prism_kicks = "Kicks"
 	L.dark_constellation = "Stars"
 	L.the_dark_archangel = "Big Boom"
-	L.dark_rune = "Memory Mark"
 	L.dark_rune_bar = "Solve the Game"
 
 	L.starsplinter = "Blazes" -- Mythic intermission and P4 bar text
-	L.starsplinter_you = "Blaze"
+	L.starsplinter_singular = "Blaze"
 
 	L.left = "[L] %s" -- left/west group bars in p3
 	L.right = "[R] %s" -- right/east group bars in p3
@@ -92,6 +91,31 @@ if L then
 	L.custom_select_limit_warnings_value4 = "Show warnings for left side only."
 	L.custom_select_limit_warnings_value5 = "Show warnings for right side only."
 end
+
+mod:SetRenames({
+	[1253915] = "heavens_glaives", -- XXX Sets the default to the value of L.heavens_glaives (value cached on use so the localized version is loaded)
+	[1279420] = "beams", -- Dark Quasar -- XXX Uses CL.beams as default as there is no L.beams defined
+	[1249620] = "deaths_dirge",
+	[1249609] = {"mark", "dark_rune_bar"}, -- Dark Rune -- XXX Extra associated strings show as a count (+1) on the main page, config label is just a title cased version of the string key currently
+	[1251386] = "prism_kicks", -- Safeguard Prism
+	[1267049] = "heavens_lance",
+
+	[1282441] = {"starsplinter", "starsplinter_singular"},
+
+	[1284525] = "beams", -- Galvanize
+	[1282412] = "dodge", -- Core Harvest
+	[1281194] = "knockback", -- Dark Meltdown
+
+	[1266388] = "dark_constellation",
+	[1250898] = "the_dark_archangel",
+	[1266897] = "soaks", -- Light Siphon
+
+	[1284980] = "deaths_dirge", -- Grim Symphony
+	[1284931] = "prism_kicks", -- Termination Prism
+	[1273158] = "deaths_dirge", -- Death's Requiem
+
+	[1276525] = {nil, "left", "right"}, -- Heaven & Hell -- XXX Example of associated strings with no default rename
+})
 
 --------------------------------------------------------------------------------
 -- Initialization
@@ -137,30 +161,8 @@ function mod:GetOptions()
 		[1253915] = -32197, -- Stage One: Final Tolls
 		[1284525] = -33638, -- Stage Two: The Dark Reactor
 		[1250898] = -33639, -- Stage Three: Midnight Falls
-	},{
-		[1253915] = L.heavens_glaives,
-		[1279420] = CL.beams, -- Dark Quasar
-		[1249620] = L.deaths_dirge,
-		[1249609] = L.dark_rune,
-		[1251386] = L.prism_kicks, -- Safeguard Prism
-		[1267049] = L.heavens_lance,
-
-		[1284525] = CL.beams, -- Galvanize
-		[1282412] = CL.dodge, -- Core Harvest
-		[1281194] = CL.knockback, -- Dark Meltdown
-		[1266388] = L.dark_constellation,
-		[1250898] = L.the_dark_archangel,
-		[1266897] = CL.soaks, -- Light Siphon
-
-		[1284980] = L.deaths_dirge, -- Grim Symphony
-		[1284931] = L.prism_kicks, -- Termination Prism
-		[1273158] = L.deaths_dirge, -- Death's Requiem
-		[1282441] = L.starsplinter,
+		[1273158] = "mythic",
 	}
-end
-
-function mod:GetName(key)
-	return self.notes and self.notes[key] or self:SpellName(key)
 end
 
 function mod:OnBossEnable()
@@ -540,15 +542,15 @@ function mod:ENCOUNTER_WARNING(_, info)
 	if stage == 1 or stage == 3 then
 		if info.severity == 2 then -- Dark Rune
 			self:PersonalMessage(1249609)
-			-- self:Bar(1249609, stage == 1 and 10 or 15, L.dark_rune_bar)
+			-- self:Bar(1249609, stage == 1 and 10 or 15, self:GetName("dark_rune_bar"))
 		end
 	elseif stage == 2 or stage == 4 then
 		if info.severity == 2 then -- Galvanize
 			self:PersonalMessage(1284525)
 		elseif info.severity == 1 then -- Starsplinter
 			-- (p2 is set on intermission start)
-			self:PersonalMessage(1282441, nil, L.starsplinter_you)
-			-- self:Bar(1282441, 3, CL.you:format(L.starsplinter_you))
+			self:PersonalMessage(1282441, nil, self:GetName("starsplinter_singular"))
+			-- self:Bar(1282441, 3, CL.you:format(self:GetName("starsplinter_singular")))
 		end
 	end
 end
@@ -681,7 +683,7 @@ function mod:IntoTheDarkwell(duration)
 		self:Bar(1279420, 10.5, CL.count:format(self:GetName(1279420), quasarCount))
 		self:ScheduleTimer("IntermissionDarkQuasar", 10.5)
 		if self:Mythic() then
-			self:Bar(1282441, 38, L.starsplinter)
+			self:Bar(1282441, 38, self:GetName(1282441)) -- Starsplinter
 		end
 	end
 

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -40,6 +40,7 @@ end
 
 local colorModule
 local soundModule
+local renameModule
 local configFrame
 
 local showToggleOptions, getAdvancedToggleOption = nil, nil
@@ -322,6 +323,7 @@ do
 		soundModule = BigWigs:GetPlugin("Sounds")
 		acr:RegisterOptionsTable("BigWigs: Colors Override", colorModule:SetColorOptions("dummy", "dummy"), true)
 		acr:RegisterOptionsTable("BigWigs: Sounds Override", soundModule:SetSoundOptions("dummy", "dummy"), true)
+		renameModule = BigWigs:GetPlugin("Rename", true)
 
 		loader.RegisterMessage(options, "BigWigs_PluginOptionsReady")
 		local pluginOptions = BigWigs:GetPluginOptions()
@@ -626,8 +628,28 @@ local advancedTabs = {
 	},
 }
 
+local function setRenameValue(widget, _, value)
+	local module = widget:GetUserData("module")
+	local key = widget:GetUserData("key")
+	renameModule:SetName(module, key, value)
+
+	-- refresh
+	local dropdown = widget:GetUserData("dropdown")
+	local scrollFrame = widget:GetUserData("scrollFrame")
+	local bossOption = widget:GetUserData("option")
+	visibleSpellDescriptionWidgets = {}
+	scrollFrame:ReleaseChildren()
+	scrollFrame:AddChildren(getAdvancedToggleOption(scrollFrame, dropdown, module, bossOption))
+	scrollFrame:PerformLayout()
+end
+
+local function resetRenameValue(widget, _, value)
+	local editbox = widget:GetUserData("editbox")
+	editbox:Fire("OnEnterPressed", "")
+end
+
 function getAdvancedToggleOption(scrollFrame, dropdown, module, bossOption)
-	local dbKey, name, desc, icon, alternativeName = BigWigs:GetBossOptionDetails(module, bossOption)
+	local dbKey, name, desc, icon, optionNotes, optionRename = BigWigs:GetBossOptionDetails(module, bossOption)
 	local widgets = {}
 
 	local back = AceGUI:Create("Button")
@@ -650,8 +672,16 @@ function getAdvancedToggleOption(scrollFrame, dropdown, module, bossOption)
 	idLabel.label:SetJustifyH("RIGHT")
 	widgets[#widgets + 1] = idLabel
 
+	local abilityLabel = name
+	if optionNotes then
+		abilityLabel = L.noteLabel:format(abilityLabel, optionNotes)
+	end
+	if optionRename and optionRename ~= name then
+		abilityLabel = L.renameLabel:format(abilityLabel, optionRename)
+	end
+
 	local check = AceGUI:Create("CheckBox")
-	check:SetLabel(alternativeName and L.alternativeName:format(name, alternativeName) or name)
+	check:SetLabel(abilityLabel)
 	check:SetTriState(true)
 	check:SetFullWidth(true)
 	check:SetDescription(desc)
@@ -667,6 +697,95 @@ function getAdvancedToggleOption(scrollFrame, dropdown, module, bossOption)
 		check:SetImage(icon, 0.07, 0.93, 0.07, 0.93)
 	end
 	widgets[#widgets + 1] = check
+
+	if not BigWigs:IsCustomBossOption(dbKey) and renameModule then -- can't rename builtins
+		if type(dbKey) == "number" then -- don't show general rename for string keys
+			local customDesc = AceGUI:Create("Label")
+			customDesc:SetText(L.renameHeader)
+			customDesc:SetColor(1, 0.82, 0)
+			customDesc:SetFullWidth(true)
+			widgets[#widgets + 1] = customDesc
+
+			local default = renameModule:GetDefaultName(module, dbKey)
+			local customName = AceGUI:Create("EditBox")
+			customName:SetText(optionRename)
+			customName:SetUserData("key", dbKey)
+			customName:SetUserData("scrollFrame", scrollFrame)
+			customName:SetUserData("dropdown", dropdown)
+			customName:SetUserData("module", module)
+			customName:SetUserData("option", bossOption)
+			customName:SetCallback("OnEnterPressed", setRenameValue)
+			customName:SetRelativeWidth(0.6)
+			widgets[#widgets + 1] = customName
+
+			local customReset = AceGUI:Create("Button")
+			customReset:SetText(L.reset)
+			customReset:SetDisabled(not optionRename or optionRename == default)
+			customReset:SetUserData("editbox", customName)
+			customReset:SetCallback("OnClick", resetRenameValue)
+			customReset:SetRelativeWidth(0.2)
+			widgets[#widgets + 1] = customReset
+
+			local customDefault = AceGUI:Create("Button")
+			customDefault:SetText(L.spellName)
+			customDefault:SetDisabled(not optionRename or optionRename == name or default == module:SpellName(dbKey))
+			customDefault:SetUserData("editbox", customName)
+			customDefault:SetUserData("spell", name)
+			customDefault:SetUserData("desc", L.spellNameResetDesc)
+			customDefault:SetCallback("OnEnter", slaveOptionMouseOver)
+			customDefault:SetCallback("OnLeave", optionsTooltip_Hide)
+			customDefault:SetCallback("OnClick", function(widget, event, value)
+				local editbox = widget:GetUserData("editbox")
+				editbox:Fire("OnEnterPressed", widget:GetUserData("spell"))
+			end)
+			customDefault:SetRelativeWidth(0.2)
+			widgets[#widgets + 1] = customDefault
+		end
+
+		local renameOptions = module.renameOptions and module.renameOptions[dbKey]
+		if renameOptions and renameOptions[2] then -- 2+ are extra associated strings
+			local spacer = AceGUI:Create("Label")
+			spacer:SetFullWidth(true)
+			widgets[#widgets + 1] = spacer
+
+			for i = 2, #renameOptions do
+				local stringKey = renameOptions[i]
+				local default = module.localization[stringKey]
+				local text = renameModule:GetName(module, stringKey) or default
+				-- XXX just title case the key for now
+				local label = stringKey:gsub("_", " "):gsub("(%a)(%w*)", function(a, b) return a:upper()..b:lower() end)
+				-- suffix -> localized category
+				-- local titles = {
+				-- 	me = "On Me",
+				-- 	cast = "Cast Message",
+				-- 	castbar = "Cast Bar",
+				-- 	singular = "Singular Form (Target Message/Bar)",
+				-- }
+				-- local suffix = stringKey:match("_(.-)$")
+				-- local label = titles[suffix]
+
+				local customStringName = AceGUI:Create("EditBox")
+				customStringName:SetLabel(label)
+				customStringName:SetText(text)
+				customStringName:SetUserData("key", stringKey)
+				customStringName:SetUserData("scrollFrame", scrollFrame)
+				customStringName:SetUserData("dropdown", dropdown)
+				customStringName:SetUserData("module", module)
+				customStringName:SetUserData("option", bossOption)
+				customStringName:SetCallback("OnEnterPressed", setRenameValue)
+				customStringName:SetRelativeWidth(0.6)
+				widgets[#widgets + 1] = customStringName
+
+				local customStringReset = AceGUI:Create("Button")
+				customStringReset:SetText(L.reset)
+				customStringReset:SetDisabled(text == default)
+				customStringReset:SetUserData("editbox", customStringName)
+				customStringReset:SetCallback("OnClick", resetRenameValue)
+				customStringReset:SetRelativeWidth(0.4)
+				widgets[#widgets + 1] = customStringReset
+			end
+		end
+	end
 
 	-- Create role-specific secondary checkbox
 	for i, key in next, BigWigs:GetRoleOptions() do
@@ -742,7 +861,7 @@ local function customDropdownValueChanged(widget, _, value)
 end
 
 local function getDefaultToggleOption(scrollFrame, dropdown, module, bossOption)
-	local dbKey, name, desc, icon, alternativeName = BigWigs:GetBossOptionDetails(module, bossOption)
+	local dbKey, name, desc, icon, optionNotes, optionRename = BigWigs:GetBossOptionDetails(module, bossOption)
 
 	if type(dbKey) == "string" and dbKey:find("^custom_select_") then
 		local moduleLocale = module:GetLocale()
@@ -782,8 +901,27 @@ local function getDefaultToggleOption(scrollFrame, dropdown, module, bossOption)
 		end
 	end
 
+	if optionRename == name then optionRename = nil end -- altname set to spell name
+	local renameOptions = module.renameOptions and module.renameOptions[dbKey]
+	if renameOptions and #renameOptions > 1 then
+		local count = #renameOptions - 1
+		if optionRename then
+			optionRename = ("%s, +%d"):format(optionRename, count)
+		else
+			optionRename = ("+%d"):format(count)
+		end
+	end
+
+	local abilityLabel = name
+	if optionNotes then
+		abilityLabel = ("%s (|cFF436EEE%s|r)"):format(abilityLabel, optionNotes)
+	end
+	if optionRename then
+		abilityLabel = ("%s (|cFFFFFF99%s|r)"):format(abilityLabel, optionRename)
+	end
+
 	local check = AceGUI:Create("CheckBox")
-	check:SetLabel(alternativeName and L.alternativeName:format(name, alternativeName) or name)
+	check:SetLabel(abilityLabel)
 	check:SetTriState(true)
 	check:SetRelativeWidth(0.85)
 	check:SetUserData("key", dbKey)

--- a/Plugins/BigWigs_Plugins.toc
+++ b/Plugins/BigWigs_Plugins.toc
@@ -58,3 +58,4 @@ Wipe.lua
 BattleRes.lua
 Timeline.lua
 PrivateAuras.lua
+Rename.lua

--- a/Plugins/Rename.lua
+++ b/Plugins/Rename.lua
@@ -1,0 +1,84 @@
+-------------------------------------------------------------------------------
+-- Module Declaration
+--
+
+local plugin = BigWigs:NewPlugin("Rename", {
+	"GetDefaultName",
+	"GetName",
+	"SetName",
+})
+if not plugin then return end
+
+local CL = BigWigsAPI:GetLocale("BigWigs: Common")
+
+--------------------------------------------------------------------------------
+-- Options
+--
+
+plugin.defaultDB = {}
+
+--------------------------------------------------------------------------------
+-- API
+--
+
+function plugin:GetDefaultName(module, key)
+	if not module or not key then
+		BigWigs:Error(("Rename: Missing module or key (%q, %q)"):format(tostring(module), tostring(key)))
+		return
+	end
+
+	local moduleLocale = module:GetLocale()
+
+	-- Check if there is a module set rename
+	if module.renameOptions and module.renameOptions[key] then
+		local replacementKey = module.renameOptions[key][1]
+		if replacementKey then
+			return moduleLocale[replacementKey] or CL[replacementKey]
+		end
+	end
+	-- Return spell name or localized string
+	if type(key) == "number" then
+		return module:SpellName(key)
+	end
+	return moduleLocale[key]
+end
+
+function plugin:GetName(module, key)
+	if not module or not key then
+		BigWigs:Error(("Rename: Missing module or key (%q, %q)"):format(tostring(module), tostring(key)))
+		return
+	end
+
+	local moduleName = module.name
+	local name = plugin.db.profile[moduleName] and plugin.db.profile[moduleName][key]
+	if not name and module.renameOptions and module.renameOptions[key] then
+		local replacementKey = module.renameOptions[key][1]
+		if replacementKey then
+			local moduleLocale = module:GetLocale()
+			name = moduleLocale[replacementKey] or CL[replacementKey]
+		end
+	end
+	return name
+end
+
+function plugin:SetName(module, key, value)
+	if not module or not key then
+		BigWigs:Error(("Rename: Missing module or key (%q, %q)"):format(tostring(module), tostring(key)))
+		return
+	end
+
+	if value == "" or value == self:GetDefaultName(module, key) then
+		value = nil
+	elseif value then
+		value = strtrim(value)
+		if value == "" then
+			value = nil
+		end
+	end
+
+	local moduleName = module.name
+	if value and not plugin.db.profile[moduleName] then
+		plugin.db.profile[moduleName] = {}
+	end
+	plugin.db.profile[moduleName][key] = value
+end

--- a/Plugins/modules.xml
+++ b/Plugins/modules.xml
@@ -23,5 +23,6 @@
 <Script file="BattleRes.lua"/>
 <Script file="Timeline.lua"/>
 <Script file="PrivateAuras.lua"/>
+<Script file="Rename.lua"/>
 
 </Ui>


### PR DESCRIPTION
Updated for Midnight from #1881.

```lua
mod:SetRenames({
	[key1] = "locale_key1". 
	[key2] = {"locale_key2", "locale_key2_extra"}.
})
```

to set the renames (similar to the notes block in `:GetOptions()`, except you use the key name instead of the value) and `:GetName(key)` or `:GetName("locale_key")` does the rest in the module.

Included an update MidnightFalls with comments in the `:SetRenames()`  for usage.

<img width="1065" height="814" alt="image" src="https://github.com/user-attachments/assets/42c8ae57-16dd-46e6-a55a-efc8253be75b" />

<img width="1056" height="816" alt="image" src="https://github.com/user-attachments/assets/fb9b5a6a-965a-465e-b4d6-7b4d09ed6a07" />

