### PR TITLE
Add option to disable Audio Channel and Cache size override

### DIFF
--- a/Loader.lua
+++ b/Loader.lua
@@ -1186,20 +1186,6 @@ do
 	end
 	RegisterAddonMessagePrefix(dbmPrefix) -- DBM
 end
-do
-	local num = tonumber(C_CVar.GetCVar("Sound_NumChannels")) or 0
-	if num < 90 then
-		C_CVar.SetCVar("Sound_NumChannels", "90") -- 64 is the default, enforce a little higher as a minimum to prevent sound clipping issues with addons
-	end
-	local maxCache = tonumber(C_CVar.GetCVar("Sound_MaxCacheSizeInBytes")) or 0
-	if maxCache < 134217728 then
-		C_CVar.SetCVar("Sound_MaxCacheSizeInBytes", "134217728") -- "Large (128MB)" is the default, enforce it as a minimum
-	end
-	local maxSize = tonumber(C_CVar.GetCVar("Sound_MaxCacheableSizeInBytes")) or 0
-	if maxSize < 174762 then
-		C_CVar.SetCVar("Sound_MaxCacheableSizeInBytes", "174762") -- "174762" (170KB) is the default, enforce it as a minimum
-	end
-end
 
 -- LibDBIcon setup
 if type(BigWigsIconDB) ~= "table" then
@@ -1231,6 +1217,7 @@ do
 		profile = {
 			showZoneMessages = true,
 			fakeDBMVersion = false,
+			enforceSoundSettings = true,
 			englishSayMessages = false,
 			bossModMessagesDisabled = false,
 			bossModNameplatesDisabled = false,
@@ -1261,6 +1248,21 @@ do
 			db.profile[k] = nil
 		elseif type(v) ~= defaultType then
 			db.profile[k] = defaults.profile[k]
+		end
+	end
+
+	if db.profile.enforceSoundSettings then
+		local num = tonumber(C_CVar.GetCVar("Sound_NumChannels")) or 0
+		if num < 90 then
+			C_CVar.SetCVar("Sound_NumChannels", "90") -- 64 is the default, enforce a little higher as a minimum to prevent sound clipping issues with addons
+		end
+		local maxCache = tonumber(C_CVar.GetCVar("Sound_MaxCacheSizeInBytes")) or 0
+		if maxCache < 134217728 then
+			C_CVar.SetCVar("Sound_MaxCacheSizeInBytes", "134217728") -- "Large (128MB)" is the default, enforce it as a minimum
+		end
+		local maxSize = tonumber(C_CVar.GetCVar("Sound_MaxCacheableSizeInBytes")) or 0
+		if maxSize < 174762 then
+			C_CVar.SetCVar("Sound_MaxCacheableSizeInBytes", "174762") -- "174762" (170KB) is the default, enforce it as a minimum
 		end
 	end
 end

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -153,6 +153,8 @@ L.listAbilities = "List abilities in group chat"
 
 L.dbmFaker = "Pretend I'm using DBM"
 L.dbmFakerDesc = "If a DBM user does a version check to see who's using DBM, they will see you on the list. Useful for guilds that force using DBM."
+L.enforceSoundSettings = "Override sound CVar limits"
+L.enforceSoundSettingsDesc = "Enforce a minimum of 90 Audio Channels and 128MB Audio Cache Size on load to prevent addon sounds from being clipped. Disabling this may cause missing warning sounds during encounters."
 L.zoneMessages = "Show zone messages"
 L.zoneMessagesDesc = "Disabling this will stop showing messages when you enter a zone that BigWigs has timers for, but you don't have installed. We recommend you leave this turned on as it's the only notification you will get if we suddenly create timers for a new zone that you find useful."
 L.englishSayMessages = "English-only say messages"

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -142,6 +142,13 @@ local aceConfigTableMainBigWigsTab = {
 					order = 33,
 					width = "full",
 				},
+				enforceSoundSettings = {
+					type = "toggle",
+					name = L.enforceSoundSettings,
+					desc = L.enforceSoundSettingsDesc,
+					order = 34,
+					width = "full",
+				},
 				separator4 = {
 					type = "description",
 					name = " ",


### PR DESCRIPTION
## Summary

Adds a "Override sound CVar limits" toggle to the BigWigs General settings panel. When disabled, BigWigs will no longer enforce minimum values for `Sound_NumChannels`, `Sound_MaxCacheSizeInBytes`, or `Sound_MaxCacheableSizeInBytes` on load/reload.

The option defaults to **enabled**, preserving current behavior for existing users.

## Why

BigWigs unconditionally overrides three sound-related CVars on every load/reload with no way to opt out. For some players, particularly those on older hardware or those experiencing performance issues tied to WoW's audio system, the enforced values (90 audio channels, 128MB cache) can contribute to stuttering, FPS drops, or other problems.

Reports of sound settings impacting performance:

- [DX12 freezing and black screens related to sound settings](https://www.reddit.com/r/wow/comments/1sc9dz4/to_anyone_suffering_from_dx12_freezing_and_black/)
- [Turning off sound gains 50+ FPS](https://www.reddit.com/r/wow/comments/1sib2x6/turning_off_the_sound_in_game_will_gain_you_50_fps/)
- [Reducing audio channels/cache fixes stuttering](https://www.reddit.com/r/wow/comments/1tdpwsn/another_one_trick_for_stuttering/)

## Changes

- **Loader.lua**: Moved CVar enforcement block after DB initialization and gated it behind the new profile setting
- **Options/Options.lua**: Added toggle in the General settings panel
- **Locales/enUS.lua**: Added name and description strings

## Notes

- Default is `true` — no behavior change for existing users
- Users who disable this accept the risk of potential sound clipping during encounters
- The description warns users about possible missing warning sounds

## Testing
- Verified in game that changes work
- Flag defaults to enabled and continues to override settings on reload
- When disabled play made changes persist