### PR TITLE
Plugins/Pull: Fix Auto Combat Log for Mythic+

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -185,6 +185,7 @@ files["Plugins/Proximity.lua"].ignore = {
 	"113/UnitInPhase", -- Classic support
 }
 files["Plugins/Pull.lua"].ignore = {
+	"113/C_ChallengeMode",
 	"113/C_ChatInfo",
 	"113/ClearOverrideBindings",
 	"113/GetPlayerInfoByGUID",

--- a/Plugins/Pull.lua
+++ b/Plugins/Pull.lua
@@ -11,6 +11,21 @@ if not plugin then return end
 
 local DoCountdown = BigWigsLoader.DoCountdown
 local isLogging = false
+local pendingLogStopTimer
+local function cancelLogStop()
+	if pendingLogStopTimer then
+		plugin:CancelTimer(pendingLogStopTimer)
+		pendingLogStopTimer = nil
+	end
+end
+local function scheduleLogStop(delay)
+	cancelLogStop()
+	pendingLogStopTimer = plugin:ScheduleTimer(function()
+		pendingLogStopTimer = nil
+		isLogging = false
+		LoggingCombat(false)
+	end, delay)
+end
 local LibSharedMedia = LibStub("LibSharedMedia-3.0")
 local SOUND = LibSharedMedia.MediaType and LibSharedMedia.MediaType.SOUND or "sound"
 
@@ -293,14 +308,17 @@ do
 
 		if BigWigsLoader.isRetail or BigWigsLoader.isMists then
 			self:RegisterEvent("CHALLENGE_MODE_START")
+			self:RegisterEvent("CHALLENGE_MODE_COMPLETED")
+			self:RegisterEvent("CHALLENGE_MODE_RESET")
 		end
 	end
 end
 
 function plugin:OnPluginDisable()
+	cancelLogStop()
 	if isLogging then
 		isLogging = false
-		LoggingCombat(isLogging)
+		LoggingCombat(false)
 	end
 end
 
@@ -326,6 +344,18 @@ do
 				return OrigIsEncounterInProgress()
 			end
 		end
+	end
+end
+
+local IsChallengeModeActive
+if BigWigsLoader.isRetail or BigWigsLoader.isMists then
+	local GetActiveChallengeMapID = C_ChallengeMode.GetActiveChallengeMapID
+	function IsChallengeModeActive()
+		return GetActiveChallengeMapID() ~= nil
+	end
+else
+	function IsChallengeModeActive()
+		return false
 	end
 end
 
@@ -385,6 +415,7 @@ do
 		BigWigs:Print(L.pullStartedBy:format(name))
 		timer = self:ScheduleRepeatingTimer(printPull, 1)
 		if self.db.profile.combatLog then
+			cancelLogStop()
 			isLogging = true
 			LoggingCombat(isLogging)
 		end
@@ -438,12 +469,23 @@ end
 
 function plugin:CHALLENGE_MODE_START()
 	self:Blizz_StopCountdown() -- Stop any active pull timers when a Mythic+ countdown is started
+	cancelLogStop() -- A new key starting shouldn't be cut short by a pending stop from the previous one
+	if self.db.profile.combatLog then
+		isLogging = true
+		LoggingCombat(true)
+	end
 end
 
-function plugin:BigWigs_OnBossWin()
+function plugin:CHALLENGE_MODE_COMPLETED()
 	if isLogging then
-		isLogging = false
-		self:SimpleTimer(function() LoggingCombat(false) end, 2) -- Delay to prevent any death events being cut out the log
+		scheduleLogStop(5) -- Delay to prevent any events after the final blow being cut out of the log
+	end
+end
+plugin.CHALLENGE_MODE_RESET = plugin.CHALLENGE_MODE_COMPLETED
+
+function plugin:BigWigs_OnBossWin()
+	if isLogging and not IsChallengeModeActive() then -- Don't stop per-boss during an active Mythic+ key, only when the key itself ends
+		scheduleLogStop(2) -- Delay to prevent any death events being cut out the log
 	end
 end
 


### PR DESCRIPTION
## Summary

This pull request refactors and improves the combat logging logic in the `Plugins/Pull.lua` plugin, especially around Mythic+ (Challenge Mode) dungeons. The main focus is to ensure that combat logging starts and stops at the correct times, preventing premature log stops and handling edge cases for both boss encounters and Mythic+ runs. 

Raid automatic logging behaviour remains untouched.

## Combat logging improvements:
* Introduced `scheduleLogStop` and `cancelLogStop` functions to reliably delay and manage stopping combat logging, preventing logs from being cut off too early. [[1]](diffhunk://#diff-c844d830949e39b68aced83e2042f700ed2e988e3d7263de4d15a1699ba8830bR14-R28) [[2]](diffhunk://#diff-c844d830949e39b68aced83e2042f700ed2e988e3d7263de4d15a1699ba8830bR418)
* Changed the logic so that combat logging only stops at the end of a Mythic+ key (using `CHALLENGE_MODE_COMPLETED` or `CHALLENGE_MODE_RESET`), not after each boss win during an active key. [[1]](diffhunk://#diff-c844d830949e39b68aced83e2042f700ed2e988e3d7263de4d15a1699ba8830bR472-R488) [[2]](diffhunk://#diff-c844d830949e39b68aced83e2042f700ed2e988e3d7263de4d15a1699ba8830bR350-R361)
* Ensured that any pending log stop timers are cancelled when a new Mythic+ key starts or when the plugin is disabled, improving reliability. [[1]](diffhunk://#diff-c844d830949e39b68aced83e2042f700ed2e988e3d7263de4d15a1699ba8830bR311-R321) [[2]](diffhunk://#diff-c844d830949e39b68aced83e2042f700ed2e988e3d7263de4d15a1699ba8830bR472-R488)

## Mythic+ event handling:
* Added event handlers for `CHALLENGE_MODE_COMPLETED` and `CHALLENGE_MODE_RESET` to properly manage logging at the end of a Mythic+ run. [[1]](diffhunk://#diff-c844d830949e39b68aced83e2042f700ed2e988e3d7263de4d15a1699ba8830bR311-R321) [[2]](diffhunk://#diff-c844d830949e39b68aced83e2042f700ed2e988e3d7263de4d15a1699ba8830bR472-R488)
* Added an `IsChallengeModeActive` helper to check if a Mythic+ run is currently active, ensuring correct logging behavior.

## Configuration:
* Updated `.luacheckrc` to ignore `C_ChallengeMode` in `Plugins/Pull.lua` for linting purposes.

## Fixes:
#1330
