### PR TITLE
Plugins/Auras: Fix taint

### DIFF
--- a/Plugins/Auras.lua
+++ b/Plugins/Auras.lua
@@ -1895,8 +1895,7 @@ do
 		-- These won't trigger an container update, so update them first
 		for index = 1, auraContainer:GetAuraGroupFrameCount("debuffs") do
 			local aura = auraContainer:GetAuraGroupFrame("debuffs", index)
-
-			if not InCombatLockdown() then
+			if aura:CanBeAccessedInContext() then
 				UpdateAuraFrame(aura, optionsDB)
 			end
 		end


### PR DESCRIPTION
Changing the sizes of aura buttons or its children is not permitted in certain situations, like combat, encounter lockdown, or even just being in a pvp instance, so the previous combat check was not sufficient.