### PR TITLE
Auras: fix secret width error when setting the border backdrop

### DIFF
--- a/Plugins/Auras.lua
+++ b/Plugins/Auras.lua
@@ -2097,13 +2097,15 @@ do
 		aura:ClearDispelTypeTextures()
 
 		if optionsDB.borderName ~= "None" then
+			-- Corner-anchoring to the aura would make GetWidth() secret, and SetBackdrop does arithmetic on it
+			local borderSize = optionsDB.size + optionsDB.borderOffset * 2
+			aura.border:ClearAllPoints()
+			aura.border:SetPoint("CENTER")
+			aura.border:SetSize(borderSize, borderSize)
 			aura.border:SetBackdrop({
 				edgeFile = LibSharedMedia:Fetch("border", optionsDB.borderName),
 				edgeSize = optionsDB.borderSize,
 			})
-			aura.border:ClearAllPoints()
-			aura.border:SetPoint("TOPLEFT", -optionsDB.borderOffset, optionsDB.borderOffset)
-			aura.border:SetPoint("BOTTOMRIGHT", optionsDB.borderOffset, -optionsDB.borderOffset)
 
 			for pieceName in pairs(backdropTextureUVs) do -- logic copied from Blizzard_SharedXML/Backdrop.lua
 				local borderRegion = aura.border[pieceName]


### PR DESCRIPTION
With a border configured, `UpdateAuraFrame` anchors `aura.border` to both corners of the aura button. The container positions that button from secret data, so the border's rect is derived from secret coordinates and `GetWidth()` returns a secret number. `SetBackdrop` then fails inside Blizzard's mixin:

```
4x Blizzard_SharedXML/Backdrop.lua:226: attempt to perform arithmetic on local 'width' (a secret number value, while execution tainted by 'BigWigs_Core')
[Blizzard_SharedXML/Backdrop.lua]:226: in function 'SetupTextureCoordinates'
[Blizzard_SharedXML/Backdrop.lua]:348: in function 'SetBackdrop'
[BigWigs_Plugins/Auras.lua]:2100: in function <BigWigs_Plugins/Auras.lua:2066>
[BigWigs_Plugins/Auras.lua]:2192: in function <BigWigs_Plugins/Auras.lua:2161>
```

The `CanBeAccessedInContext()` guard from #2701 passes here, since data access and geometry secrecy are separate aspects: the locals at the fault show a plain `effectiveScale` next to secret `width`/`height`.

Anchoring the border by center with an explicit size is geometrically identical (a `size + 2 * borderOffset` square centered on the aura), but the width Blizzard reads is a plain number. Setting the size before `SetBackdrop` covers the first coordinate pass, and the explicit size also keeps the `OnSizeChanged` path safe.
