### PR TITLE
Auras: fix the border backdrop width still being secret

### DIFF
--- a/Plugins/Auras.lua
+++ b/Plugins/Auras.lua
@@ -1965,6 +1965,10 @@ do
 	-- 	durationFormater:SetMillisecondsThreshold(3)
 	-- end
 
+	local function BorderGetSize(border)
+		return border.plainSize
+	end
+
 	function InitializeAuraFrame(aura, optionsDB)
 		optionsDB = optionsDB or aura:GetParent().db
 		local size = optionsDB.size
@@ -2023,6 +2027,10 @@ do
 
 		local border = CreateFrame("Frame", nil, aura, "BackdropTemplate")
 		border:SetFrameLevel(border:GetFrameLevel() + 1) -- show the border above the cooldown swipe
+		-- The widget GetWidth/GetHeight return secrets for anything anchored to the aura,
+		-- explicit size or not, and SetBackdrop does arithmetic on them
+		border.GetWidth = BorderGetSize
+		border.GetHeight = BorderGetSize
 		aura.border = border
 
 		local dispelIcon = border:CreateTexture(nil, "OVERLAY")
@@ -2113,8 +2121,8 @@ do
 		aura:ClearDispelTypeTextures()
 
 		if optionsDB.borderName ~= "None" then
-			-- Corner-anchoring to the aura would make GetWidth() secret, and SetBackdrop does arithmetic on it
 			local borderSize = optionsDB.size + optionsDB.borderOffset * 2
+			aura.border.plainSize = borderSize
 			aura.border:ClearAllPoints()
 			aura.border:SetPoint("CENTER")
 			aura.border:SetSize(borderSize, borderSize)


### PR DESCRIPTION
Follow-up to #2708, which turned out to be insufficient: `GetWidth()` is documented `SecretWhenAnchoringSecret` (SimpleScriptRegionAPIDocumentation.lua), so a region anchored into the container's layout returns a secret width even with an explicit size, and the same error persists:

```
6x Blizzard_SharedXML/Backdrop.lua:226: attempt to perform arithmetic on local 'width' (a secret number value, while execution tainted by 'BigWigs_Core')
[Blizzard_SharedXML/Backdrop.lua]:226: in function 'SetupTextureCoordinates'
[Blizzard_SharedXML/Backdrop.lua]:348: in function 'SetBackdrop'
[BigWigs_Plugins/Auras.lua]:2105: in function <BigWigs_Plugins/Auras.lua:2066>
```

The border's intended size is known, so this shadows `GetWidth`/`GetHeight` on that one frame and the backdrop coordinate math reads the plain number, in both the `SetBackdrop` and `OnSizeChanged` paths. Nothing secure calls these on the border; only the backdrop mixin does, under our taint anyway.

The rest of `ApplyBackdrop` is safe once execution gets past the width read: the piece textures carry secret aspects from `AddDispelTypeTexture`, but the setters hit there (`SetTexture`, `SetVertexColor`, `SetTexCoord`) are all `AllowedWhenTainted`, and the first two already run before the crash line in every errored session.
