### PR TITLE
Fix aura filter and removed sound typos

### DIFF
--- a/Plugins/Auras.lua
+++ b/Plugins/Auras.lua
@@ -2294,7 +2294,7 @@ do
 
 		auraContainer:SetAuraGroupMaxFrameCount("debuffs", optionsDB.maxIcons)
 		auraContainer:SetAuraGroupCandidateFilters("debuffs", {
-			isFromPlayerorPlayerPet = false,
+			isFromPlayerOrPlayerPet = false,
 			excludeSpellIDs = {
 				-- LFG debuffs
 				[26013] = true, -- Deserter

--- a/Plugins/Sound.lua
+++ b/Plugins/Sound.lua
@@ -497,9 +497,9 @@ do
 				local onRemovedSound = bossModule:GetAuraRemovedSound(spellId)
 				if not onRemovedSound then
 					onRemovedSound = bossModule:GetAuraRemovedSoundDefault(spellId)
-					local hasGlobalSound = validGlobalSounds[onAppliedSound]
+					local hasGlobalSound = validGlobalSounds[onRemovedSound]
 					if hasGlobalSound then
-						onAppliedSound = db.media[hasGlobalSound]
+						onRemovedSound = db.media[hasGlobalSound]
 					end
 				end
 				if onAppliedSound and onAppliedSound ~= "None" then


### PR DESCRIPTION
Fix a couple obvious typos.

The `isFromPlayerOrPlayerPet` one is especially impactful. Right now, a lot of clutter shows up in the boss debuffs display.