### PR TITLE
Improve LittleWigs detection and chat prints

### DIFF
--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -101,6 +101,7 @@ local updateData = function(module)
 
 	local _, _, diff, _, currentMaxPlayers = GetInstanceInfo()
 	difficulty, maxPlayers = diff, currentMaxPlayers
+	module.isLittleWigs = loader:IsLittleWigsZone(module.instanceId or (module.mapId and -module.mapId))
 
 	local _, role, position = LibSpec.MySpecialization()
 	myRole, myRolePosition = role, position
@@ -517,20 +518,12 @@ end
 --- Show an error after the encounter has ended
 -- @string message the message to show to the user
 -- @bool chatOnly if the message should only be shown in chat, and not sent to the error handler
--- @bool littleWigsMessage if the chat message should mention LittleWigs instead of BigWigs
-function boss:Error(message, chatOnly, littleWigsMessage)
+function boss:Error(message, chatOnly)
 	if chatOnly then
-		if littleWigsMessage then
-			if not self.errorChatPrintsLittleWigs then
-				self.errorChatPrintsLittleWigs = {}
-			end
-			self.errorChatPrintsLittleWigs[#self.errorChatPrintsLittleWigs+1] = message
-		else
-			if not self.errorChatPrints then
-				self.errorChatPrints = {}
-			end
-			self.errorChatPrints[#self.errorChatPrints+1] = message
+		if not self.errorChatPrints then
+			self.errorChatPrints = {}
 		end
+		self.errorChatPrints[#self.errorChatPrints+1] = message
 	else
 		if not self.errorMessages then
 			self.errorMessages = {}
@@ -550,7 +543,7 @@ do
 		end
 		local stage = self:GetStage() or 0
 		local eventErrorMessage = unhandledEventString:format(GetTime() - self.stageTime, stage, eventInfo.spellName, eventInfo.spellID, eventInfo.duration)
-		self:Error(eventErrorMessage, true, self:GetMaxPlayers() <= 5)
+		self:Error(eventErrorMessage, true)
 		self:Debug(("TL event ID %d after %.1fs (stage %s) was missed."):format(eventInfo.id, GetTime() - self.stageTime, stage))
 	end
 end
@@ -599,6 +592,16 @@ function boss:Enable(isWipe)
 		end
 	end
 end
+--- Returns the version of the addon owning this module
+-- e.g. "422#abc1234" or "v12.1.0"
+function boss:GetVersion()
+	if self.isLittleWigs then
+		return loader.littlewigsVersion or "unknown"
+	end
+	local version = BigWigsAPI.GetVersion()
+	return ("%d#%s"):format(version, BigWigsAPI.GetVersionHash())
+end
+
 function boss:Disable(isWipe)
 	if self:IsEnabled() then
 		self.enabled = nil
@@ -679,7 +682,7 @@ function boss:Disable(isWipe)
 
 		if self.missing then
 			local newBarError = "New timer for %q at stage %d with placement %d and value %.2f."
-			local errorHeader = format("BigWigs is missing timers on %q running %d#%s, tell the devs!", self:DifficultyName(), BigWigsAPI.GetVersion(), BigWigsAPI.GetVersionHash())
+			local errorHeader = format("%s is missing timers on %q running %s, tell the devs!", self.isLittleWigs and "LittleWigs" or "BigWigs", self:DifficultyName(), self:GetVersion())
 			local errorStrings = {errorHeader}
 			for key, stageTbl in next, self.missing do
 				for stage = 0, 5, 0.5 do
@@ -688,43 +691,33 @@ function boss:Disable(isWipe)
 						for timeEntry = 2, count do
 							local t = stageTbl[stage][timeEntry] - stageTbl[stage][timeEntry-1]
 							local text = format(newBarError, key, stage, timeEntry-1, t)
-							core:Print(text)
+							core:Print(text, self.isLittleWigs)
 							errorStrings[#errorStrings+1] = text
 						end
 					end
 				end
 			end
 			if #errorStrings > 1 then
-				core:Print(errorHeader)
+				core:Print(errorHeader, self.isLittleWigs)
 				local timersText = table.concat(errorStrings, "\n")
-				core:Error(timersText, true)
+				core:Error(timersText, true, self.isLittleWigs)
 			end
 			self.missing = nil
 		end
 		if self.errorMessages then
 			for i = 1, #self.errorMessages do
-				core:Error(self.errorMessages[i])
+				core:Error(self.errorMessages[i], nil, self.isLittleWigs)
 			end
 			self.errorMessages = nil
 		end
 		if self.errorChatPrints then
 			for i = 1, #self.errorChatPrints do
-				core:Print(self.errorChatPrints[i])
+				core:Print(self.errorChatPrints[i], self.isLittleWigs)
 			end
 			self.errorChatPrints = nil
-			core:Print(("Extra info: %s, %s (%d#%s)"):format(self.moduleName, self:DifficultyName(), BigWigsAPI.GetVersion(), BigWigsAPI.GetVersionHash()))
+			core:Print(("Extra info: %s, %s (%s)"):format(self.moduleName, self:DifficultyName(), self:GetVersion()), self.isLittleWigs)
 			if not self.noAfterBossError and self:ShouldShowBars() then
-				core:Error(("%q timeline issue. Show the devs a screenshot of the messages in your chat, NOT this error message."):format(self.moduleName), true)
-			end
-		end
-		if self.errorChatPrintsLittleWigs then
-			for i = 1, #self.errorChatPrintsLittleWigs do
-				core:Print(self.errorChatPrintsLittleWigs[i], true)
-			end
-			self.errorChatPrintsLittleWigs = nil
-			core:Print(("Extra info: %s, %s (%d#%s)"):format(self.moduleName, self:DifficultyName(), BigWigsAPI.GetVersion(), BigWigsAPI.GetVersionHash()), true)
-			if not self.noAfterBossError and self:ShouldShowBars() then
-				core:Error(("%q timeline issue. Show the devs a screenshot of the messages in your chat, NOT this error message."):format(self.moduleName), true)
+				core:Error(("%q timeline issue. Show the devs a screenshot of the messages in your chat, NOT this error message."):format(self.moduleName), true, self.isLittleWigs)
 			end
 		end
 	end
@@ -2619,7 +2612,7 @@ do
 					local spellId = auraTable.spellId
 					if not blacklist[spellId] then
 						blacklist[spellId] = true
-						core:Error(format("Found spell '%s' using id %d on %s, tell the authors!", auraTable.name, spellId, self:DifficultyName()))
+						core:Error(format("Found spell '%s' using id %d on %s, tell the authors!", auraTable.name, spellId, self:DifficultyName()), nil, self.isLittleWigs)
 					end
 					local value = auraTable.points and auraTable.points[1]
 					t1, t2, t3, t4, t5 = auraTable.name, auraTable.applications, auraTable.duration, auraTable.expirationTime, value
@@ -2668,7 +2661,7 @@ do
 					local spellId = auraTable.spellId
 					if not blacklist[spellId] then
 						blacklist[spellId] = true
-						core:Error(format("Found spell '%s' using id %d on %s, tell the authors!", auraTable.name, spellId, self:DifficultyName()))
+						core:Error(format("Found spell '%s' using id %d on %s, tell the authors!", auraTable.name, spellId, self:DifficultyName()), nil, self.isLittleWigs)
 					end
 					local value = auraTable.points and auraTable.points[1]
 					t1, t2, t3, t4, t5 = auraTable.name, auraTable.applications, auraTable.duration, auraTable.expirationTime, value
@@ -2772,7 +2765,7 @@ do
 	function boss:SelectGossipID(id, skipConfirmDialogBox)
 		local npc = UnitName("npc")
 		if npc then
-			core:Print(format(autotalk_notice, npc))
+			core:Print(format(autotalk_notice, npc), self.isLittleWigs)
 		end
 		SelectOption(id, "", skipConfirmDialogBox) -- Don't think the text arg is something we will ever need
 	end
@@ -5036,7 +5029,7 @@ do
 						end
 					elseif result ~= 11 then -- AddOnMessageLockdown
 						local errorMsg = format("Failed to send boss comm %q. Error code: %d", messageToTransmit, result)
-						core:Error(errorMsg)
+						core:Error(errorMsg, nil, self.isLittleWigs)
 					end
 				end
 				self:SendMessage("BigWigs_BossComm", msg, extra, myName)

--- a/Core/BossPrototype_Classic.lua
+++ b/Core/BossPrototype_Classic.lua
@@ -177,6 +177,7 @@ local updateData = function(module)
 
 	local _, _, diff, _, currentMaxPlayers = GetInstanceInfo()
 	difficulty, maxPlayers = diff, currentMaxPlayers
+	module.isLittleWigs = loader:IsLittleWigsZone(module.instanceId or (module.mapId and -module.mapId))
 
 	UpdateDispelStatus()
 	UpdateInterruptStatus()
@@ -590,20 +591,12 @@ end
 --- Show an error after the encounter has ended
 -- @string message the message to show to the user
 -- @bool chatOnly if the message should only be shown in chat, and not sent to the error handler
--- @bool littleWigsMessage if the chat message should mention LittleWigs instead of BigWigs
-function boss:Error(message, chatOnly, littleWigsMessage)
+function boss:Error(message, chatOnly)
 	if chatOnly then
-		if littleWigsMessage then
-			if not self.errorChatPrintsLittleWigs then
-				self.errorChatPrintsLittleWigs = {}
-			end
-			self.errorChatPrintsLittleWigs[#self.errorChatPrintsLittleWigs+1] = message
-		else
-			if not self.errorChatPrints then
-				self.errorChatPrints = {}
-			end
-			self.errorChatPrints[#self.errorChatPrints+1] = message
+		if not self.errorChatPrints then
+			self.errorChatPrints = {}
 		end
+		self.errorChatPrints[#self.errorChatPrints+1] = message
 	else
 		if not self.errorMessages then
 			self.errorMessages = {}
@@ -623,7 +616,7 @@ do
 		end
 		local stage = self:GetStage() or 0
 		local eventErrorMessage = unhandledEventString:format(GetTime() - self.stageTime, stage, eventInfo.spellName, eventInfo.spellID, eventInfo.duration)
-		self:Error(eventErrorMessage, true, self:GetMaxPlayers() <= 5)
+		self:Error(eventErrorMessage, true)
 		self:Debug(("TL event ID %d after %.1fs (stage %s) was missed."):format(eventInfo.id, GetTime() - self.stageTime, stage))
 	end
 end
@@ -672,6 +665,16 @@ function boss:Enable(isWipe)
 		end
 	end
 end
+--- Returns the version of the addon owning this module
+-- e.g. "422#abc1234" or "v12.1.0"
+function boss:GetVersion()
+	if self.isLittleWigs then
+		return loader.littlewigsVersion or "unknown"
+	end
+	local version = BigWigsAPI.GetVersion()
+	return ("%d#%s"):format(version, BigWigsAPI.GetVersionHash())
+end
+
 function boss:Disable(isWipe)
 	if self:IsEnabled() then
 		self.enabled = nil
@@ -753,7 +756,7 @@ function boss:Disable(isWipe)
 
 		if self.missing then
 			local newBarError = "New timer for %q at stage %d with placement %d and value %.2f."
-			local errorHeader = format("BigWigs is missing timers on %q running %d#%s, tell the devs!", self:DifficultyName(), BigWigsAPI.GetVersion(), BigWigsAPI.GetVersionHash())
+			local errorHeader = format("%s is missing timers on %q running %s, tell the devs!", self.isLittleWigs and "LittleWigs" or "BigWigs", self:DifficultyName(), self:GetVersion())
 			local errorStrings = {errorHeader}
 			for key, stageTbl in next, self.missing do
 				for stage = 0, 5, 0.5 do
@@ -762,43 +765,33 @@ function boss:Disable(isWipe)
 						for timeEntry = 2, count do
 							local t = stageTbl[stage][timeEntry] - stageTbl[stage][timeEntry-1]
 							local text = format(newBarError, key, stage, timeEntry-1, t)
-							core:Print(text)
+							core:Print(text, self.isLittleWigs)
 							errorStrings[#errorStrings+1] = text
 						end
 					end
 				end
 			end
 			if #errorStrings > 1 then
-				core:Print(errorHeader)
+				core:Print(errorHeader, self.isLittleWigs)
 				local timersText = table.concat(errorStrings, "\n")
-				core:Error(timersText, true)
+				core:Error(timersText, true, self.isLittleWigs)
 			end
 			self.missing = nil
 		end
 		if self.errorMessages then
 			for i = 1, #self.errorMessages do
-				core:Error(self.errorMessages[i])
+				core:Error(self.errorMessages[i], nil, self.isLittleWigs)
 			end
 			self.errorMessages = nil
 		end
 		if self.errorChatPrints then
 			for i = 1, #self.errorChatPrints do
-				core:Print(self.errorChatPrints[i])
+				core:Print(self.errorChatPrints[i], self.isLittleWigs)
 			end
 			self.errorChatPrints = nil
-			core:Print(("Extra info: %s, %s (%d#%s)"):format(self.moduleName, self:DifficultyName(), BigWigsAPI.GetVersion(), BigWigsAPI.GetVersionHash()))
+			core:Print(("Extra info: %s, %s (%s)"):format(self.moduleName, self:DifficultyName(), self:GetVersion()), self.isLittleWigs)
 			if not self.noAfterBossError and self:ShouldShowBars() then
-				core:Error(("%q timeline issue. Show the devs a screenshot of the messages in your chat, NOT this error message."):format(self.moduleName), true)
-			end
-		end
-		if self.errorChatPrintsLittleWigs then
-			for i = 1, #self.errorChatPrintsLittleWigs do
-				core:Print(self.errorChatPrintsLittleWigs[i], true)
-			end
-			self.errorChatPrintsLittleWigs = nil
-			core:Print(("Extra info: %s, %s (%d#%s)"):format(self.moduleName, self:DifficultyName(), BigWigsAPI.GetVersion(), BigWigsAPI.GetVersionHash()), true)
-			if not self.noAfterBossError and self:ShouldShowBars() then
-				core:Error(("%q timeline issue. Show the devs a screenshot of the messages in your chat, NOT this error message."):format(self.moduleName), true)
+				core:Error(("%q timeline issue. Show the devs a screenshot of the messages in your chat, NOT this error message."):format(self.moduleName), true, self.isLittleWigs)
 			end
 		end
 	end
@@ -2684,7 +2677,7 @@ do
 					local spellId = auraTable.spellId
 					if not blacklist[spellId] then
 						blacklist[spellId] = true
-						core:Error(format("Found spell '%s' using id %d on %s, tell the authors!", auraTable.name, spellId, self:DifficultyName()))
+						core:Error(format("Found spell '%s' using id %d on %s, tell the authors!", auraTable.name, spellId, self:DifficultyName()), nil, self.isLittleWigs)
 					end
 					local value = auraTable.points and auraTable.points[1]
 					t1, t2, t3, t4, t5 = auraTable.name, auraTable.applications, auraTable.duration, auraTable.expirationTime, value
@@ -2733,7 +2726,7 @@ do
 					local spellId = auraTable.spellId
 					if not blacklist[spellId] then
 						blacklist[spellId] = true
-						core:Error(format("Found spell '%s' using id %d on %s, tell the authors!", auraTable.name, spellId, self:DifficultyName()))
+						core:Error(format("Found spell '%s' using id %d on %s, tell the authors!", auraTable.name, spellId, self:DifficultyName()), nil, self.isLittleWigs)
 					end
 					local value = auraTable.points and auraTable.points[1]
 					t1, t2, t3, t4, t5 = auraTable.name, auraTable.applications, auraTable.duration, auraTable.expirationTime, value
@@ -2837,7 +2830,7 @@ do
 	function boss:SelectGossipID(id, skipConfirmDialogBox)
 		local npc = UnitName("npc")
 		if npc then
-			core:Print(format(autotalk_notice, npc))
+			core:Print(format(autotalk_notice, npc), self.isLittleWigs)
 		end
 		SelectOption(id, "", skipConfirmDialogBox) -- Don't think the text arg is something we will ever need
 	end
@@ -4756,7 +4749,7 @@ do
 						end
 					elseif result ~= 11 then -- AddOnMessageLockdown
 						local errorMsg = format("Failed to send boss comm %q. Error code: %d", messageToTransmit, result)
-						core:Error(errorMsg)
+						core:Error(errorMsg, nil, self.isLittleWigs)
 					end
 				end
 				self:SendMessage("BigWigs_BossComm", msg, extra, myName)

--- a/Core/Core.lua
+++ b/Core/Core.lua
@@ -393,11 +393,11 @@ function core:Print(msg, isLittleWigs)
 	end
 end
 
-function core:Error(msg, noPrint)
+function core:Error(msg, noPrint, isLittleWigs)
 	if not noPrint then
-		core:Print(msg)
+		core:Print(msg, isLittleWigs)
 	end
-	geterrorhandler()("BigWigs: ".. msg)
+	geterrorhandler()((isLittleWigs and "LittleWigs: " or "BigWigs: ").. msg)
 end
 
 -------------------------------------------------------------------------------

--- a/Loader.lua
+++ b/Loader.lua
@@ -50,7 +50,6 @@ do
 	public.isCata = tbl.isCata
 	public.isMists = tbl.isMists
 	public.dbmPrefix = "D5"
-	public.littlewigsVersionString = L.missingAddOnPopup:format("LittleWigs")
 
 	-- START: MAGIC PACKAGER VOODOO VERSION STUFF
 	local REPO = "REPO"
@@ -1028,17 +1027,9 @@ do
 		if name == "LittleWigs" then
 			if GetAddOnMetadata(i, "X-LittleWigs-Repo") then
 				public.usingLittleWigsRepo = true
-				public.littlewigsVersionString = L.littlewigsSourceCheckout
+				public.littlewigsVersion = "repo"
 			else
-				local version = GetAddOnMetadata(i, "Version")
-				if version then
-					local alpha = strfind(version, "-", nil, true)
-					if alpha then
-						public.littlewigsVersionString = L.littlewigsAlphaRelease:format(version)
-					else
-						public.littlewigsVersionString = L.littlewigsOfficialRelease:format(version)
-					end
-				end
+				public.littlewigsVersion = GetAddOnMetadata(i, "Version") -- e.g. "v12.1.0" or "v12.1.0-1"
 			end
 		end
 	end
@@ -2114,7 +2105,7 @@ public.RegisterMessage(mod, "BigWigs_BossModuleRegistered")
 function mod:BigWigs_CoreEnabled()
 	local _, _, _, _, _, _, _, instanceID = GetInstanceInfoModified()
 	local zoneAddon = public.zoneTbl[instanceID]
-	if zoneAddon and zoneAddon:find("LittleWigs", nil, true) then
+	if public:IsLittleWigsZone(instanceID) then
 		dataBroker.icon = "Interface\\AddOns\\BigWigs\\Media\\Icons\\minimap_party.tga"
 	elseif zoneAddon and zoneAddon:find("BigWigs", nil, true) and zoneAddon ~= public.currentExpansion.name then
 		dataBroker.icon = "Interface\\AddOns\\BigWigs\\Media\\Icons\\minimap_legacy.tga"
@@ -2158,6 +2149,11 @@ end
 function public:IsAddOnEnabled(name)
 	local addonState = GetAddOnEnableState(name, myGUID)
 	return addonState == 2
+end
+
+function public:IsLittleWigsZone(zoneID)
+	local zoneAddon = public.zoneTbl[zoneID]
+	return zoneAddon ~= nil and zoneAddon:find("LittleWigs", nil, true) ~= nil
 end
 
 -----------------------------------------------------------------------

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -1871,6 +1871,17 @@ do
 		end
 	end
 
+	local function getLittleWigsStatusText()
+		if loader.usingLittleWigsRepo then
+			return L.littlewigsSourceCheckout
+		end
+		local version = loader.littlewigsVersion
+		if not version then
+			return L.missingAddOnPopup:format("LittleWigs")
+		end
+		return (string.find(version, "-", nil, true) and L.littlewigsAlphaRelease or L.littlewigsOfficialRelease):format(version)
+	end
+
 	local currentlyOpenContainer, openPath
 	local function onTabGroupSelected(widget, event, value)
 		visibleSpellDescriptionWidgets = {}
@@ -1939,7 +1950,7 @@ do
 				end
 			elseif value == "littlewigs" then
 				configFrame:SetTitle("LittleWigs")
-				configFrame:SetStatusText(" "..loader.littlewigsVersionString)
+				configFrame:SetStatusText(" "..getLittleWigsStatusText())
 				defaultHeader = loader.currentExpansion.littleWigsDefault
 				-- add an entry for each expansion
 				for i = 1, #expansionHeader do

--- a/Plugins/Statistics.lua
+++ b/Plugins/Statistics.lua
@@ -463,7 +463,7 @@ function plugin:BigWigs_OnBossWin(_, module)
 		local difficultyText = activeDurations[journalID][2]
 
 		if self.db.profile.printVictory then
-			self:SimpleTimer(function() BigWigs:Print(L.bossVictoryPrint:format(module.displayName, BigWigsAPI.SecondsToTime(elapsed))) end, 1)
+			self:SimpleTimer(function() BigWigs:Print(L.bossVictoryPrint:format(module.displayName, BigWigsAPI.SecondsToTime(elapsed)), module.isLittleWigs) end, 1)
 		end
 
 		local diff = module:Difficulty()
@@ -484,7 +484,7 @@ function plugin:BigWigs_OnBossWin(_, module)
 			if not sDB.best or elapsed < sDB.best then
 				if self.db.profile.printNewFastestVictory and sDB.best then
 					local t = sDB.best-elapsed
-					self:SimpleTimer(function() BigWigs:Print(L.newFastestVictoryPrint:format(BigWigsAPI.SecondsToTime(t))) end, 1.1)
+					self:SimpleTimer(function() BigWigs:Print(L.newFastestVictoryPrint:format(BigWigsAPI.SecondsToTime(t)), module.isLittleWigs) end, 1.1)
 				end
 				sDB.best = elapsed
 				sDB.bestDate = date("%Y/%m/%d")
@@ -515,12 +515,12 @@ do
 
 			if elapsed > GetMinimumEncounterDuration(module) then
 				if self.db.profile.printDefeat then
-					BigWigs:Print(L.bossDefeatPrint:format(module.displayName, BigWigsAPI.SecondsToTime(elapsed)))
+					BigWigs:Print(L.bossDefeatPrint:format(module.displayName, BigWigsAPI.SecondsToTime(elapsed)), module.isLittleWigs)
 				end
 
 				local diff = module:Difficulty()
 				if not difficultyText and IsInRaid() and not dontPrint[diff] then
-					BigWigs:Error("Tell the devs, the stats for this boss were not recorded because a new difficulty id was found: "..diff)
+					BigWigs:Error("Tell the devs, the stats for this boss were not recorded because a new difficulty id was found: "..diff, nil, module.isLittleWigs)
 				elseif difficultyText then
 					local instanceID = module:GetZoneID()
 					local sDB = BigWigsStatsDB[instanceID][journalID][difficultyText]
@@ -541,7 +541,7 @@ do
 						end
 					end
 					if total ~= "" then
-						BigWigs:Print(L.healthPrint:format(total))
+						BigWigs:Print(L.healthPrint:format(total), module.isLittleWigs)
 					end
 				elseif unitInfo then
 					local total = ""
@@ -556,7 +556,7 @@ do
 						end
 					end
 					if total ~= "" then
-						BigWigs:Print(L.healthPrint:format(total))
+						BigWigs:Print(L.healthPrint:format(total), module.isLittleWigs)
 					end
 				end
 			end


### PR DESCRIPTION
Check for LW vs BW based on zoneID.

Errors now say LittleWigs:
<img width="931" height="129" alt="image" src="https://github.com/user-attachments/assets/e0cd9eff-6a76-47ef-829c-8d25900be578" />

Timeline prints now include LittleWigs version instead of BigWigs version (and fight-end prints say LittleWigs instead of BigWigs):
<img width="587" height="105" alt="image" src="https://github.com/user-attachments/assets/b677f8e6-7b7a-453f-a561-e9dd2580a0f7" />

Also covers gossip and other misc module prints.