### PR TITLE
Add a search box to sound selection dropdowns

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -11,6 +11,8 @@ L.shortSecondsOnly = "%d Sec" -- 28 Seconds
 L.shortSubTenSeconds = "%.1f Sec" -- 3.2 Seconds
 L.accept = "Accept"
 L.cancel = "Cancel"
+L.search = "Type to search..."
+L.searchMore = "+%d more"
 L.confirm_profile_swap = "The addon |cFF436EEE\"%s\"|r wants to automatically swap your BigWigs profile to a different profile called:\n\n|cFF33FF99\"%s\"|r\n\nAre you sure you want to do this?"
 
 -- Core.lua

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -11,8 +11,6 @@ L.shortSecondsOnly = "%d Sec" -- 28 Seconds
 L.shortSubTenSeconds = "%.1f Sec" -- 3.2 Seconds
 L.accept = "Accept"
 L.cancel = "Cancel"
-L.search = "Type to search..."
-L.searchMore = "+%d more"
 L.confirm_profile_swap = "The addon |cFF436EEE\"%s\"|r wants to automatically swap your BigWigs profile to a different profile called:\n\n|cFF33FF99\"%s\"|r\n\nAre you sure you want to do this?"
 
 -- Core.lua

--- a/Options/Libs/AceGUIWidget-SharedDropdown.lua
+++ b/Options/Libs/AceGUIWidget-SharedDropdown.lua
@@ -47,6 +47,32 @@ do
 		self:Fire("OnClosed")
 	end)
 
+	local PopulateItems -- defined below, forward-declared for use in the search box and toggle handler
+
+	local function Reopen(self)
+		_pullout:Open("TOPLEFT", self.frame, "BOTTOMLEFT", 0, self.label:IsShown() and -2 or 0)
+		_pullout.scrollStatus.scrollvalue = 0
+		_pullout.scrollStatus.offset = 0
+		_pullout:FixScroll()
+	end
+
+	local search = CreateFrame("EditBox", nil, _pullout.frame, "InputBoxTemplate")
+	search:SetAutoFocus(false)
+	search:SetHeight(20)
+	search:SetPoint("BOTTOMLEFT", _pullout.frame, "TOPLEFT", 8, 3)
+	search:SetPoint("BOTTOMRIGHT", _pullout.frame, "TOPRIGHT", -8, 3)
+	search:SetScript("OnEscapePressed", search.ClearFocus)
+	local placeholder = search:CreateFontString(nil, "ARTWORK", "GameFontDisableSmall")
+	placeholder:SetPoint("LEFT", 6, 0)
+	placeholder:SetText("Search")
+	search:SetScript("OnTextChanged", function(this)
+		placeholder:SetShown(this:GetText() == "")
+		local self = _pullout.userdata.obj
+		if not self then return end
+		PopulateItems(self, this:GetText())
+		Reopen(self)
+	end)
+
 	--[[ UI event handler ]]--
 
 	local function Control_OnEnter(this)
@@ -79,10 +105,10 @@ do
 			_pullout.frame:SetFrameLevel(self.frame:GetFrameLevel() + 1)
 			fixlevels(_pullout.frame, _pullout.frame:GetChildren())
 			_pullout:SetWidth(self.pulloutWidth or self.frame:GetWidth())
-			_pullout:Open("TOPLEFT", self.frame, "BOTTOMLEFT", 0, self.label:IsShown() and -2 or 0)
-			_pullout.scrollStatus.scrollvalue = 0
-			_pullout.scrollStatus.offset = 0
-			_pullout:FixScroll()
+			search:SetText("")
+			placeholder:Show()
+			PopulateItems(self, "")
+			Reopen(self)
 			AceGUI:SetFocus(self)
 		end
 	end
@@ -207,13 +233,18 @@ do
 			return tostring(x) < tostring(y)
 		end
 	end
-	-- exported
-	local function SetList(self, list, order, itemType)
-		self.list = list or {}
-		if list and self.list == _pullout.list and #list == #self.list then return end
-		_pullout.list = self.list
+
+	function PopulateItems(self, filterText, list, order, itemType)
+		list = list or self.list
+		order = order or self.order
+		itemType = itemType or self.itemType
 		_pullout:Clear()
 		if not list then return end
+		filterText = filterText ~= "" and filterText:lower() or nil
+
+		local function matches(text)
+			return not filterText or tostring(text):lower():find(filterText, 1, true) ~= nil
+		end
 
 		if type(order) ~= "table" then
 			for v in pairs(list) do
@@ -222,14 +253,28 @@ do
 			tsort(sortlist, sortTbl)
 
 			for i, key in ipairs(sortlist) do
-				AddListItem(self, key, list[key], itemType)
+				if matches(list[key]) then
+					AddListItem(self, key, list[key], itemType)
+				end
 				sortlist[i] = nil
 			end
 		else
 			for i, key in ipairs(order) do
-				AddListItem(self, key, list[key], itemType)
+				if matches(list[key]) then
+					AddListItem(self, key, list[key], itemType)
+				end
 			end
 		end
+	end
+
+	-- exported
+	local function SetList(self, list, order, itemType)
+		self.list = list or {}
+		self.order = order
+		self.itemType = itemType
+		if list and self.list == _pullout.list and #list == #self.list then return end
+		_pullout.list = self.list
+		PopulateItems(self, "", self.list, order, itemType)
 	end
 
 	-- exported

--- a/Options/Libs/AceGUIWidget-SharedDropdown.lua
+++ b/Options/Libs/AceGUIWidget-SharedDropdown.lua
@@ -56,6 +56,14 @@ do
 		_pullout:FixScroll()
 	end
 
+	local searchTimer
+	local function CancelSearchTimer()
+		if searchTimer then
+			searchTimer:Cancel()
+			searchTimer = nil
+		end
+	end
+
 	local search = CreateFrame("EditBox", nil, _pullout.frame, "InputBoxTemplate")
 	search:SetAutoFocus(false)
 	search:SetHeight(20)
@@ -64,13 +72,18 @@ do
 	search:SetScript("OnEscapePressed", search.ClearFocus)
 	local placeholder = search:CreateFontString(nil, "ARTWORK", "GameFontDisableSmall")
 	placeholder:SetPoint("LEFT", 6, 0)
-	placeholder:SetText("Search")
+	placeholder:SetText("Type to search...")
 	search:SetScript("OnTextChanged", function(this)
 		placeholder:SetShown(this:GetText() == "")
-		local self = _pullout.userdata.obj
-		if not self then return end
-		PopulateItems(self, this:GetText())
-		Reopen(self)
+		CancelSearchTimer()
+		local text = this:GetText()
+		searchTimer = BigWigsLoader.CTimerNewTimer(0.15, function()
+			searchTimer = nil
+			local self = _pullout.userdata.obj
+			if not self then return end
+			PopulateItems(self, text)
+			Reopen(self)
+		end)
 	end)
 
 	--[[ UI event handler ]]--
@@ -88,6 +101,7 @@ do
 	local function Dropdown_OnHide(this)
 		local self = this.obj
 		if self.open then
+			CancelSearchTimer()
 			_pullout:Close()
 		end
 	end
@@ -95,6 +109,7 @@ do
 	local function Dropdown_TogglePullout(this)
 		local self = this.obj
 		_pullout.userdata.obj = self
+		CancelSearchTimer()
 
 		if self.open then
 			self.open = nil
@@ -110,6 +125,7 @@ do
 			PopulateItems(self, "")
 			Reopen(self)
 			AceGUI:SetFocus(self)
+			search:SetFocus()
 		end
 	end
 
@@ -141,6 +157,7 @@ do
 	-- exported, AceGUI callback
 	local function OnRelease(self)
 		if self.open then
+			CancelSearchTimer()
 			_pullout:Close()
 		end
 
@@ -174,6 +191,7 @@ do
 	-- exported
 	local function ClearFocus(self)
 		if self.open then
+			CancelSearchTimer()
 			_pullout:Close()
 		end
 	end

--- a/Options/Libs/AceGUIWidget-SharedDropdown.lua
+++ b/Options/Libs/AceGUIWidget-SharedDropdown.lua
@@ -73,6 +73,22 @@ do
 	local placeholder = search:CreateFontString(nil, "ARTWORK", "GameFontDisableSmall")
 	placeholder:SetPoint("LEFT", 6, 0)
 	placeholder:SetText("Type to search...")
+	local moreLabel = search:CreateFontString(nil, "ARTWORK", "GameFontDisableSmall")
+	moreLabel:SetPoint("RIGHT", -6, 0)
+	moreLabel:Hide()
+
+	-- Rebuilding every matching item widget is what's actually expensive (not the filtering
+	-- itself), so cap how many get created per rebuild and let the search narrow the rest down.
+	local MAX_RESULTS = 60
+	local function ApplyFilter(self, text)
+		local overflow = PopulateItems(self, text)
+		moreLabel:SetShown(overflow > 0)
+		if overflow > 0 then
+			moreLabel:SetText(("+%d more"):format(overflow))
+		end
+		Reopen(self)
+	end
+
 	search:SetScript("OnTextChanged", function(this)
 		placeholder:SetShown(this:GetText() == "")
 		CancelSearchTimer()
@@ -81,8 +97,7 @@ do
 			searchTimer = nil
 			local self = _pullout.userdata.obj
 			if not self then return end
-			PopulateItems(self, text)
-			Reopen(self)
+			ApplyFilter(self, text)
 		end)
 	end)
 
@@ -122,8 +137,7 @@ do
 			_pullout:SetWidth(self.pulloutWidth or self.frame:GetWidth())
 			search:SetText("")
 			placeholder:Show()
-			PopulateItems(self, "")
-			Reopen(self)
+			ApplyFilter(self, "")
 			AceGUI:SetFocus(self)
 			search:SetFocus()
 		end
@@ -257,11 +271,21 @@ do
 		order = order or self.order
 		itemType = itemType or self.itemType
 		_pullout:Clear()
-		if not list then return end
+		if not list then return 0 end
 		filterText = filterText ~= "" and filterText:lower() or nil
 
 		local function matches(text)
 			return not filterText or tostring(text):lower():find(filterText, 1, true) ~= nil
+		end
+
+		local shown = 0
+		local function addIfMatch(key, text)
+			if matches(text) then
+				if shown < MAX_RESULTS then
+					AddListItem(self, key, text, itemType)
+				end
+				shown = shown + 1
+			end
 		end
 
 		if type(order) ~= "table" then
@@ -271,18 +295,16 @@ do
 			tsort(sortlist, sortTbl)
 
 			for i, key in ipairs(sortlist) do
-				if matches(list[key]) then
-					AddListItem(self, key, list[key], itemType)
-				end
+				addIfMatch(key, list[key])
 				sortlist[i] = nil
 			end
 		else
 			for i, key in ipairs(order) do
-				if matches(list[key]) then
-					AddListItem(self, key, list[key], itemType)
-				end
+				addIfMatch(key, list[key])
 			end
 		end
+
+		return shown > MAX_RESULTS and (shown - MAX_RESULTS) or 0
 	end
 
 	-- exported

--- a/Options/Libs/AceGUIWidget-SharedDropdown.lua
+++ b/Options/Libs/AceGUIWidget-SharedDropdown.lua
@@ -49,8 +49,16 @@ do
 
 	local PopulateItems -- defined below, forward-declared for use in the search box and toggle handler
 
+	-- Extra vertical space the search box claims from the pullout's own frame. The external
+	-- Dropdown-Pullout sizes its frame purely from item count (see AddItem's "h + 34"), with
+	-- no idea we've pushed its scroll area down to make room for the search box, so that has
+	-- to be compensated for here or short result lists end up with a squashed, near-invisible
+	-- scroll viewport.
+	local HEADER_HEIGHT = 20
+
 	local function Reopen(self)
 		_pullout:Open("TOPLEFT", self.frame, "BOTTOMLEFT", 0, self.label:IsShown() and -2 or 0)
+		_pullout.frame:SetHeight(_pullout.frame:GetHeight() + HEADER_HEIGHT)
 		_pullout.scrollStatus.scrollvalue = 0
 		_pullout.scrollStatus.offset = 0
 		_pullout:FixScroll()
@@ -67,14 +75,14 @@ do
 	-- SearchBoxTemplate already provides a localized instructional text (the global SEARCH
 	-- string), a search icon and a clear button, so there's nothing left to build by hand.
 	local search = CreateFrame("EditBox", nil, _pullout.frame, "SearchBoxTemplate")
-	search:SetHeight(20)
-	search:SetPoint("TOPLEFT", _pullout.frame, "TOPLEFT", 10, -8)
-	search:SetPoint("TOPRIGHT", _pullout.frame, "TOPRIGHT", -10, -8)
+	search:SetHeight(HEADER_HEIGHT)
+	search:SetPoint("TOPLEFT", _pullout.frame, "TOPLEFT", 14, -8)
+	search:SetPoint("TOPRIGHT", _pullout.frame, "TOPRIGHT", -14, -8)
 
 	-- The pullout's scroll area is anchored by the external Dropdown-Pullout widget itself;
 	-- push it down to make room for the search box instead of floating the box on top of it.
 	_pullout.scrollFrame:ClearAllPoints()
-	_pullout.scrollFrame:SetPoint("TOPLEFT", _pullout.frame, "TOPLEFT", 6, -32)
+	_pullout.scrollFrame:SetPoint("TOPLEFT", _pullout.frame, "TOPLEFT", 6, -12 - HEADER_HEIGHT)
 	_pullout.scrollFrame:SetPoint("BOTTOMRIGHT", _pullout.frame, "BOTTOMRIGHT", -6, 12)
 
 	-- Rebuilding every matching item widget is what's actually expensive (not the filtering

--- a/Options/Libs/AceGUIWidget-SharedDropdown.lua
+++ b/Options/Libs/AceGUIWidget-SharedDropdown.lua
@@ -64,25 +64,12 @@ do
 		end
 	end
 
-	-- Locale is fetched lazily (never at file load) since this widget can load before the
-	-- BigWigs core addon that provides it, depending on load order.
-	local L
-	local function GetLocale()
-		L = L or BigWigsAPI:GetLocale("BigWigs")
-		return L
-	end
-
-	local search = CreateFrame("EditBox", nil, _pullout.frame, "InputBoxTemplate")
-	search:SetAutoFocus(false)
+	-- SearchBoxTemplate already provides a localized instructional text (the global SEARCH
+	-- string), a search icon and a clear button, so there's nothing left to build by hand.
+	local search = CreateFrame("EditBox", nil, _pullout.frame, "SearchBoxTemplate")
 	search:SetHeight(20)
 	search:SetPoint("TOPLEFT", _pullout.frame, "TOPLEFT", 10, -8)
 	search:SetPoint("TOPRIGHT", _pullout.frame, "TOPRIGHT", -10, -8)
-	search:SetScript("OnEscapePressed", search.ClearFocus)
-	local placeholder = search:CreateFontString(nil, "ARTWORK", "GameFontDisableSmall")
-	placeholder:SetPoint("LEFT", 6, 0)
-	local moreLabel = search:CreateFontString(nil, "ARTWORK", "GameFontDisableSmall")
-	moreLabel:SetPoint("RIGHT", -6, 0)
-	moreLabel:Hide()
 
 	-- The pullout's scroll area is anchored by the external Dropdown-Pullout widget itself;
 	-- push it down to make room for the search box instead of floating the box on top of it.
@@ -94,16 +81,12 @@ do
 	-- itself), so cap how many get created per rebuild and let the search narrow the rest down.
 	local MAX_RESULTS = 60
 	local function ApplyFilter(self, text)
-		local overflow = PopulateItems(self, text)
-		moreLabel:SetShown(overflow > 0)
-		if overflow > 0 then
-			moreLabel:SetText(GetLocale().searchMore:format(overflow))
-		end
+		PopulateItems(self, text)
 		Reopen(self)
 	end
 
 	search:SetScript("OnTextChanged", function(this)
-		placeholder:SetShown(this:GetText() == "")
+		SearchBoxTemplate_OnTextChanged(this)
 		CancelSearchTimer()
 		local text = this:GetText()
 		searchTimer = BigWigsLoader.CTimerNewTimer(0.15, function()
@@ -149,8 +132,6 @@ do
 			fixlevels(_pullout.frame, _pullout.frame:GetChildren())
 			_pullout:SetWidth(self.pulloutWidth or self.frame:GetWidth())
 			search:SetText("")
-			placeholder:SetText(GetLocale().search)
-			placeholder:Show()
 			ApplyFilter(self, "")
 			AceGUI:SetFocus(self)
 			search:SetFocus()

--- a/Options/Libs/AceGUIWidget-SharedDropdown.lua
+++ b/Options/Libs/AceGUIWidget-SharedDropdown.lua
@@ -64,18 +64,31 @@ do
 		end
 	end
 
+	-- Locale is fetched lazily (never at file load) since this widget can load before the
+	-- BigWigs core addon that provides it, depending on load order.
+	local L
+	local function GetLocale()
+		L = L or BigWigsAPI:GetLocale("BigWigs")
+		return L
+	end
+
 	local search = CreateFrame("EditBox", nil, _pullout.frame, "InputBoxTemplate")
 	search:SetAutoFocus(false)
 	search:SetHeight(20)
-	search:SetPoint("BOTTOMLEFT", _pullout.frame, "TOPLEFT", 8, 3)
-	search:SetPoint("BOTTOMRIGHT", _pullout.frame, "TOPRIGHT", -8, 3)
+	search:SetPoint("TOPLEFT", _pullout.frame, "TOPLEFT", 10, -8)
+	search:SetPoint("TOPRIGHT", _pullout.frame, "TOPRIGHT", -10, -8)
 	search:SetScript("OnEscapePressed", search.ClearFocus)
 	local placeholder = search:CreateFontString(nil, "ARTWORK", "GameFontDisableSmall")
 	placeholder:SetPoint("LEFT", 6, 0)
-	placeholder:SetText("Type to search...")
 	local moreLabel = search:CreateFontString(nil, "ARTWORK", "GameFontDisableSmall")
 	moreLabel:SetPoint("RIGHT", -6, 0)
 	moreLabel:Hide()
+
+	-- The pullout's scroll area is anchored by the external Dropdown-Pullout widget itself;
+	-- push it down to make room for the search box instead of floating the box on top of it.
+	_pullout.scrollFrame:ClearAllPoints()
+	_pullout.scrollFrame:SetPoint("TOPLEFT", _pullout.frame, "TOPLEFT", 6, -32)
+	_pullout.scrollFrame:SetPoint("BOTTOMRIGHT", _pullout.frame, "BOTTOMRIGHT", -6, 12)
 
 	-- Rebuilding every matching item widget is what's actually expensive (not the filtering
 	-- itself), so cap how many get created per rebuild and let the search narrow the rest down.
@@ -84,7 +97,7 @@ do
 		local overflow = PopulateItems(self, text)
 		moreLabel:SetShown(overflow > 0)
 		if overflow > 0 then
-			moreLabel:SetText(("+%d more"):format(overflow))
+			moreLabel:SetText(GetLocale().searchMore:format(overflow))
 		end
 		Reopen(self)
 	end
@@ -136,6 +149,7 @@ do
 			fixlevels(_pullout.frame, _pullout.frame:GetChildren())
 			_pullout:SetWidth(self.pulloutWidth or self.frame:GetWidth())
 			search:SetText("")
+			placeholder:SetText(GetLocale().search)
 			placeholder:Show()
 			ApplyFilter(self, "")
 			AceGUI:SetFocus(self)

--- a/Plugins/BattleRes.lua
+++ b/Plugins/BattleRes.lua
@@ -771,6 +771,7 @@ do
 						set = soundSet,
 						values = LibSharedMedia:List("sound"),
 						width = 2.5,
+						dialogControl = "SharedDropdown",
 						itemControl = "DDI-Sound",
 						disabled = IsDisabled,
 					},

--- a/Plugins/Pull.lua
+++ b/Plugins/Pull.lua
@@ -137,6 +137,7 @@ do
 				set = soundSet,
 				values = LibSharedMedia:List(SOUND),
 				width = 2.5,
+				dialogControl = "SharedDropdown",
 				itemControl = "DDI-Sound",
 			},
 			spacer2 = {
@@ -153,6 +154,7 @@ do
 				set = soundSet,
 				values = LibSharedMedia:List(SOUND),
 				width = 2.5,
+				dialogControl = "SharedDropdown",
 				itemControl = "DDI-Sound",
 			},
 			startPullMessage = {
@@ -169,6 +171,7 @@ do
 				set = soundSet,
 				values = LibSharedMedia:List(SOUND),
 				width = 2.5,
+				dialogControl = "SharedDropdown",
 				itemControl = "DDI-Sound",
 			},
 			voice = {

--- a/Plugins/Sound.lua
+++ b/Plugins/Sound.lua
@@ -157,6 +157,7 @@ plugin.pluginOptions = {
 			order = 3,
 			values = function() return soundList end,
 			width = "full",
+			dialogControl = "SharedDropdown",
 			itemControl = "DDI-Sound",
 		},
 		--privateaura = {
@@ -184,6 +185,7 @@ plugin.pluginOptions = {
 			order = 22,
 			values = function() return soundList end,
 			width = "full",
+			dialogControl = "SharedDropdown",
 			itemControl = "DDI-Sound",
 		},
 		Alert = {
@@ -192,6 +194,7 @@ plugin.pluginOptions = {
 			order = 23,
 			values = function() return soundList end,
 			width = "full",
+			dialogControl = "SharedDropdown",
 			itemControl = "DDI-Sound",
 		},
 		Info = {
@@ -200,6 +203,7 @@ plugin.pluginOptions = {
 			order = 24,
 			values = function() return soundList end,
 			width = "full",
+			dialogControl = "SharedDropdown",
 			itemControl = "DDI-Sound",
 		},
 		Long = {
@@ -208,6 +212,7 @@ plugin.pluginOptions = {
 			order = 25,
 			values = function() return soundList end,
 			width = "full",
+			dialogControl = "SharedDropdown",
 			itemControl = "DDI-Sound",
 		},
 		Warning = {
@@ -216,6 +221,7 @@ plugin.pluginOptions = {
 			order = 26,
 			values = function() return soundList end,
 			width = "full",
+			dialogControl = "SharedDropdown",
 			itemControl = "DDI-Sound",
 		},
 		-- End sound dropdowns
@@ -348,6 +354,7 @@ function plugin:OnPluginEnable()
 			values = soundList,
 			order = 2,
 			width = "full",
+			dialogControl = "SharedDropdown",
 			itemControl = "DDI-Sound",
 		}
 	end

--- a/Plugins/Victory.lua
+++ b/Plugins/Victory.lua
@@ -63,6 +63,7 @@ plugin.pluginOptions = {
 			end,
 			values = LibSharedMedia:List(SOUND),
 			width = "full",
+			dialogControl = "SharedDropdown",
 			itemControl = "DDI-Sound",
 		},
 		messages = {

--- a/Plugins/Wipe.lua
+++ b/Plugins/Wipe.lua
@@ -48,6 +48,7 @@ plugin.pluginOptions = {
 			end,
 			values = LibSharedMedia:List(SOUND),
 			width = 2,
+			dialogControl = "SharedDropdown",
 			itemControl = "DDI-Sound",
 		},
 		spacer = {

--- a/Tools/Keystones.lua
+++ b/Tools/Keystones.lua
@@ -3400,6 +3400,7 @@ do
 						set = soundSet,
 						values = LibSharedMedia:List("sound"),
 						width = 2.5,
+						dialogControl = "SharedDropdown",
 						itemControl = "DDI-Sound",
 					},
 					countEndSound = {
@@ -3410,6 +3411,7 @@ do
 						set = soundSet,
 						values = LibSharedMedia:List("sound"),
 						width = 2.5,
+						dialogControl = "SharedDropdown",
 						itemControl = "DDI-Sound",
 					},
 				},


### PR DESCRIPTION
The SharedDropdown pullout used for sound selection had no way to filter a long LibSharedMedia list
Adds a search box to the pullout that filters items by substring match as you type
Routes the sound-picker options (Sound, Wipe, Victory, Pull, BattleRes, Keystones) through SharedDropdown so they pick up the search box

**How to test**
Open Options -> Sounds, click any sound dropdown, confirm the search box appears and filters the list