### PR TITLE
Options: Support custom module sorting

### DIFF
--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -239,22 +239,17 @@ do
 		return trashModuleList[self] or false
 	end
 end
+--- Set this module's sort order in the encounter list.
+-- The list is sorted by value, lower first; the default is 0 and equal values keep registration order.
+-- @number[opt] sortOrder Sort value
+function boss:SetSortOrder(sortOrder)
+	self.sortOrder = sortOrder
+end
 
-do
-	local sharedModuleList = {}
-	--- Mark this module as being shared across multiple expansions
-	-- @bool isSharedModule If true, this module is listed after the zone's own modules in the options, regardless of load order
-	function boss:SetSharedModule(isSharedModule)
-		if isSharedModule then
-			sharedModuleList[self] = true
-		end
-	end
-
-	--- Check if this module is shared across multiple expansions
-	-- @return boolean
-	function boss:IsSharedModule()
-		return sharedModuleList[self] or false
-	end
+--- Get this module's sort order
+-- @return number Sort order, or 0 if none is set
+function boss:GetSortOrder()
+	return self.sortOrder or 0
 end
 
 do

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -241,6 +241,23 @@ do
 end
 
 do
+	local sharedModuleList = {}
+	--- Mark this module as being shared across multiple expansions
+	-- @bool isSharedModule If true, this module is listed after the zone's own modules in the options, regardless of load order
+	function boss:SetSharedModule(isSharedModule)
+		if isSharedModule then
+			sharedModuleList[self] = true
+		end
+	end
+
+	--- Check if this module is shared across multiple expansions
+	-- @return boolean
+	function boss:IsSharedModule()
+		return sharedModuleList[self] or false
+	end
+end
+
+do
 	local worldModuleList = {}
 	--- Mark this module as being a module for world bosses
 	-- @bool isWorldModule If true, this module is marked as a world module

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -478,12 +478,14 @@ do
 
 	--- Set this module's sort order in the encounter list.
 	-- The list is sorted by value, lower first; the default is 0 and equal values keep registration order.
-	-- @number[opt] order Sort value
+	-- @number order Sort value
 	function boss:SetSortOrder(order)
-		sortOrder[self] = order
+		if type(order) == "number" then
+			sortOrder[self] = order
+		end
 	end
 
-	--- Get this module's sort order
+	--- Get this module's sort order.
 	-- @return number Sort order, or 0 if none is set
 	function boss:GetSortOrder()
 		return sortOrder[self] or 0

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -239,6 +239,7 @@ do
 		return trashModuleList[self] or false
 	end
 end
+
 --- Set this module's sort order in the encounter list.
 -- The list is sorted by value, lower first; the default is 0 and equal values keep registration order.
 -- @number[opt] sortOrder Sort value

--- a/Core/BossPrototype.lua
+++ b/Core/BossPrototype.lua
@@ -240,19 +240,6 @@ do
 	end
 end
 
---- Set this module's sort order in the encounter list.
--- The list is sorted by value, lower first; the default is 0 and equal values keep registration order.
--- @number[opt] sortOrder Sort value
-function boss:SetSortOrder(sortOrder)
-	self.sortOrder = sortOrder
-end
-
---- Get this module's sort order
--- @return number Sort order, or 0 if none is set
-function boss:GetSortOrder()
-	return self.sortOrder or 0
-end
-
 do
 	local worldModuleList = {}
 	--- Mark this module as being a module for world bosses
@@ -483,6 +470,23 @@ function boss:SetStage(stage)
 			self.stageTime = GetTime()
 			self:SendMessage("BigWigs_SetStage", self, stage)
 		end
+	end
+end
+
+do
+	local sortOrder = {}
+
+	--- Set this module's sort order in the encounter list.
+	-- The list is sorted by value, lower first; the default is 0 and equal values keep registration order.
+	-- @number[opt] order Sort value
+	function boss:SetSortOrder(order)
+		sortOrder[self] = order
+	end
+
+	--- Get this module's sort order
+	-- @return number Sort order, or 0 if none is set
+	function boss:GetSortOrder()
+		return sortOrder[self] or 0
 	end
 end
 

--- a/Core/BossPrototype_Classic.lua
+++ b/Core/BossPrototype_Classic.lua
@@ -551,12 +551,14 @@ do
 
 	--- Set this module's sort order in the encounter list.
 	-- The list is sorted by value, lower first; the default is 0 and equal values keep registration order.
-	-- @number[opt] order Sort value
+	-- @number order Sort value
 	function boss:SetSortOrder(order)
-		sortOrder[self] = order
+		if type(order) == "number" then
+			sortOrder[self] = order
+		end
 	end
 
-	--- Get this module's sort order
+	--- Get this module's sort order.
 	-- @return number Sort order, or 0 if none is set
 	function boss:GetSortOrder()
 		return sortOrder[self] or 0

--- a/Core/BossPrototype_Classic.lua
+++ b/Core/BossPrototype_Classic.lua
@@ -313,19 +313,6 @@ do
 	end
 end
 
---- Set this module's sort order in the encounter list.
--- The list is sorted by value, lower first; the default is 0 and equal values keep registration order.
--- @number[opt] sortOrder Sort value
-function boss:SetSortOrder(sortOrder)
-	self.sortOrder = sortOrder
-end
-
---- Get this module's sort order
--- @return number Sort order, or 0 if none is set
-function boss:GetSortOrder()
-	return self.sortOrder or 0
-end
-
 do
 	local worldModuleList = {}
 	--- Mark this module as being a module for world bosses
@@ -556,6 +543,23 @@ function boss:SetStage(stage)
 			self.stageTime = GetTime()
 			self:SendMessage("BigWigs_SetStage", self, stage)
 		end
+	end
+end
+
+do
+	local sortOrder = {}
+
+	--- Set this module's sort order in the encounter list.
+	-- The list is sorted by value, lower first; the default is 0 and equal values keep registration order.
+	-- @number[opt] order Sort value
+	function boss:SetSortOrder(order)
+		sortOrder[self] = order
+	end
+
+	--- Get this module's sort order
+	-- @return number Sort order, or 0 if none is set
+	function boss:GetSortOrder()
+		return sortOrder[self] or 0
 	end
 end
 

--- a/Core/BossPrototype_Classic.lua
+++ b/Core/BossPrototype_Classic.lua
@@ -312,22 +312,17 @@ do
 		return trashModuleList[self] or false
 	end
 end
+--- Set this module's sort order in the encounter list.
+-- The list is sorted by value, lower first; the default is 0 and equal values keep registration order.
+-- @number[opt] sortOrder Sort value
+function boss:SetSortOrder(sortOrder)
+	self.sortOrder = sortOrder
+end
 
-do
-	local sharedModuleList = {}
-	--- Mark this module as being shared across multiple expansions
-	-- @bool isSharedModule If true, this module is listed after the zone's own modules in the options, regardless of load order
-	function boss:SetSharedModule(isSharedModule)
-		if isSharedModule then
-			sharedModuleList[self] = true
-		end
-	end
-
-	--- Check if this module is shared across multiple expansions
-	-- @return boolean
-	function boss:IsSharedModule()
-		return sharedModuleList[self] or false
-	end
+--- Get this module's sort order
+-- @return number Sort order, or 0 if none is set
+function boss:GetSortOrder()
+	return self.sortOrder or 0
 end
 
 do

--- a/Core/BossPrototype_Classic.lua
+++ b/Core/BossPrototype_Classic.lua
@@ -314,6 +314,23 @@ do
 end
 
 do
+	local sharedModuleList = {}
+	--- Mark this module as being shared across multiple expansions
+	-- @bool isSharedModule If true, this module is listed after the zone's own modules in the options, regardless of load order
+	function boss:SetSharedModule(isSharedModule)
+		if isSharedModule then
+			sharedModuleList[self] = true
+		end
+	end
+
+	--- Check if this module is shared across multiple expansions
+	-- @return boolean
+	function boss:IsSharedModule()
+		return sharedModuleList[self] or false
+	end
+end
+
+do
 	local worldModuleList = {}
 	--- Mark this module as being a module for world bosses
 	-- @bool isWorldModule If true, this module is marked as a world module

--- a/Core/BossPrototype_Classic.lua
+++ b/Core/BossPrototype_Classic.lua
@@ -312,6 +312,7 @@ do
 		return trashModuleList[self] or false
 	end
 end
+
 --- Set this module's sort order in the encounter list.
 -- The list is sorted by value, lower first; the default is 0 and equal values keep registration order.
 -- @number[opt] sortOrder Sort value

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -1693,24 +1693,17 @@ local function onZoneShow(treeWidget, instanceIdOrMapId)
 	if type(moduleList) ~= "table" then return end -- No modules registered
 
 	local zoneList, zoneSort = {}, {}
-	do
-		local sharedModules
-		for i = 1, #moduleList do
-			local module = moduleList[i]
-			zoneList[module.moduleName] = module.displayName
-			if module:IsSharedModule() then
-				sharedModules = sharedModules or {}
-				sharedModules[#sharedModules + 1] = module.moduleName
-			else
-				zoneSort[#zoneSort + 1] = module.moduleName
-			end
-		end
-		-- show shared modules last in the encounter list
-		if sharedModules then
-			for i = 1, #sharedModules do
-				zoneSort[#zoneSort + 1] = sharedModules[i]
-			end
-		end
+	for i = 1, #moduleList do
+		local module = moduleList[i]
+		zoneList[module.moduleName] = module.displayName
+		zoneSort[#zoneSort + 1] = {name = module.moduleName, order = module:GetSortOrder(), index = i}
+	end
+	-- sort according to sortOrder, ties sort by registration order
+	table.sort(zoneSort, function(a, b)
+		return a.order < b.order or (a.order == b.order and a.index < b.index)
+	end)
+	for i = 1, #zoneSort do
+		zoneSort[i] = zoneSort[i].name
 	end
 
 	local outerContainer = AceGUI:Create("SimpleGroup")

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -1694,10 +1694,22 @@ local function onZoneShow(treeWidget, instanceIdOrMapId)
 
 	local zoneList, zoneSort = {}, {}
 	do
+		local sharedModules
 		for i = 1, #moduleList do
 			local module = moduleList[i]
 			zoneList[module.moduleName] = module.displayName
-			zoneSort[i] = module.moduleName
+			if type(module.instanceId) == "table" and #module.instanceId > 1 then
+				sharedModules = sharedModules or {}
+				sharedModules[#sharedModules + 1] = module.moduleName
+			else
+				zoneSort[#zoneSort + 1] = module.moduleName
+			end
+		end
+		-- show shared modules last in the encounter list
+		if sharedModules then
+			for i = 1, #sharedModules do
+				zoneSort[#zoneSort + 1] = sharedModules[i]
+			end
 		end
 	end
 

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -1698,7 +1698,7 @@ local function onZoneShow(treeWidget, instanceIdOrMapId)
 		for i = 1, #moduleList do
 			local module = moduleList[i]
 			zoneList[module.moduleName] = module.displayName
-			if type(module.instanceId) == "table" and #module.instanceId > 1 then
+			if module:IsSharedModule() then
 				sharedModules = sharedModules or {}
 				sharedModules[#sharedModules + 1] = module.moduleName
 			else

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -1696,7 +1696,7 @@ local function onZoneShow(treeWidget, instanceIdOrMapId)
 	for i = 1, #moduleList do
 		local module = moduleList[i]
 		zoneList[module.moduleName] = module.displayName
-		zoneSort[#zoneSort + 1] = {name = module.moduleName, order = module:GetSortOrder(), index = i}
+		zoneSort[i] = {name = module.moduleName, order = module:GetSortOrder(), index = i}
 	end
 	-- sort according to sortOrder, ties sort by registration order
 	table.sort(zoneSort, function(a, b)


### PR DESCRIPTION
Usage:
```lua
mod:SetSortOrder(-2) -- before modules with sortOrder -1, etc
mod:SetSortOrder(-1) -- before other modules
mod:SetSortOrder(0) -- default
mod:SetSortOrder(1) -- after other modules
mod:SetSortOrder(2) -- after modules with sortOrder 1, etc
```
Tiebreak is registration order, same as today.