### PR TITLE
Options: Fix sound dropdown height

### DIFF
--- a/Options/Libs/AceGUIWidget-BigWigsSharedDropdown.lua
+++ b/Options/Libs/AceGUIWidget-BigWigsSharedDropdown.lua
@@ -58,7 +58,8 @@ do
 
 	local function Reopen(self)
 		_pullout:Open("TOPLEFT", self.frame, "BOTTOMLEFT", 0, self.label:IsShown() and -2 or 0)
-		_pullout.frame:SetHeight(_pullout.frame:GetHeight() + HEADER_HEIGHT)
+		local itemsHeight = #_pullout.items * 16
+		_pullout.frame:SetHeight(math.min(itemsHeight + 34, _pullout.maxHeight) + HEADER_HEIGHT)
 		_pullout.scrollStatus.scrollvalue = 0
 		_pullout.scrollStatus.offset = 0
 		_pullout:FixScroll()


### PR DESCRIPTION
_pullout.frame's height is only ever set inside AddItem (min(#items * 16 + 34, maxHeight)), which never runs when a search has zero results — so Reopen was reading a stale GetHeight() from the last non-empty search and adding another HEADER_HEIGHT on top of it every time, growing unbounded on repeated empty searches. 
This now recomputes the same height formula from the current item count directly instead of trusting GetHeight(), so it's always correct regardless of result count.

The issue should be resolved
<img width="542" height="318" alt="{D241C9D4-55E6-46CF-8A1C-6C6C53BE359B}" src="https://github.com/user-attachments/assets/120b3d2b-4ecb-474e-b030-349283187657" />
