### PR TITLE
Preserve media selections when provider addons are unavailable

### DIFF
--- a/Core/PluginPrototype.lua
+++ b/Core/PluginPrototype.lua
@@ -283,6 +283,15 @@ do
 			return fontName
 		end
 	end
+
+	-- Missing media can return after its addon is reinstalled; keep the saved selection.
+	function plugin:FetchMedia(mediaType, key, defaultKey)
+		local path = media:Fetch(mediaType, key, true)
+		if (mediaType == "border" and key == "None") or type(path) == "number" or (path and BigWigsAPI.IsValidMediaPath(path)) then
+			return path
+		end
+		return defaultKey and media:Fetch(mediaType, defaultKey)
+	end
 end
 
 --- Create a log entry in the Transcriptor addon if it is running

--- a/Plugins/AltPower.lua
+++ b/Plugins/AltPower.lua
@@ -68,7 +68,7 @@ function plugin:RestyleWindow()
 		display:SetMovable(true)
 	end
 
-	local font = LibSharedMedia:Fetch(FONT, db.fontName)
+	local font = plugin:FetchMedia(FONT, db.fontName, plugin.defaultDB.fontName)
 	local flags = nil
 	if db.monochrome and db.outline ~= "NONE" then
 		flags = "MONOCHROME," .. db.outline
@@ -180,9 +180,6 @@ do
 			end
 		end
 
-		if not LibSharedMedia:IsValid("font", plugin.db.profile.fontName) or not BigWigsAPI.IsValidMediaPath(LibSharedMedia:Fetch("font", plugin.db.profile.fontName)) then
-			plugin.db.profile.fontName = plugin.defaultDB.fontName
-		end
 		if db.fontSize < 10 or db.fontSize > 200 then
 			db.fontSize = plugin.defaultDB.fontSize
 		end

--- a/Plugins/Bars.lua
+++ b/Plugins/Bars.lua
@@ -115,12 +115,6 @@ do
 
 		SetBarStyle(db.barStyle)
 
-		if not LibSharedMedia:IsValid(FONT, db.fontName) or not BigWigsAPI.IsValidMediaPath(LibSharedMedia:Fetch("font", db.fontName)) then
-			db.fontName = plugin.defaultDB.fontName
-		end
-		if not LibSharedMedia:IsValid(STATUSBAR, db.texture) or not BigWigsAPI.IsValidMediaPath(LibSharedMedia:Fetch(STATUSBAR, db.texture)) then
-			db.texture = plugin.defaultDB.texture
-		end
 		if db.fontSize < 10 or db.fontSize > 200 then
 			db.fontSize = plugin.defaultDB.fontSize
 		end
@@ -303,8 +297,8 @@ do
 		elseif db.outline ~= "NONE" then
 			flags = db.outline
 		end
-		local font = LibSharedMedia:Fetch(FONT, db.fontName)
-		local texture = LibSharedMedia:Fetch(STATUSBAR, db.texture)
+		local font = plugin:FetchMedia(FONT, db.fontName, plugin.defaultDB.fontName)
+		local texture = plugin:FetchMedia(STATUSBAR, db.texture, plugin.defaultDB.texture)
 
 		local lastIndicatorFrame = nil
 		for bar in next, normalAnchor.bars do
@@ -1819,7 +1813,7 @@ do
 		local width, height
 		width = db.normalWidth
 		height = db.normalHeight
-		local bar = candy:New(LibSharedMedia:Fetch(STATUSBAR, db.texture), width, height)
+		local bar = candy:New(plugin:FetchMedia(STATUSBAR, db.texture, plugin.defaultDB.texture), width, height)
 		bar:SetDuration(time, not eventId and isApprox) -- isApprox is maxQueueDuration for timeline bars
 		local flags = nil
 		if db.monochrome and db.outline ~= "NONE" then
@@ -1829,7 +1823,7 @@ do
 		elseif db.outline ~= "NONE" then
 			flags = db.outline
 		end
-		local f = LibSharedMedia:Fetch(FONT, db.fontName)
+		local f = plugin:FetchMedia(FONT, db.fontName, plugin.defaultDB.fontName)
 		bar:SetFont(f, db.fontSize, flags)
 		bar:Set("bigwigs:module", module)
 		bar:Set("bigwigs:option", key)
@@ -1972,7 +1966,7 @@ function plugin:EmphasizeBar(bar, freshBar)
 	elseif db.outline ~= "NONE" then
 		flags = db.outline
 	end
-	local f = LibSharedMedia:Fetch(FONT, db.fontName)
+	local f = plugin:FetchMedia(FONT, db.fontName, plugin.defaultDB.fontName)
 	bar:SetFont(f, db.fontSizeEmph, flags)
 
 	bar:SetColor(colors:GetColor("barEmphasized", module, key))

--- a/Plugins/BattleRes.lua
+++ b/Plugins/BattleRes.lua
@@ -268,17 +268,6 @@ do
 		if plugin.db.profile.iconDesaturate < 1 or plugin.db.profile.iconDesaturate > 3 then
 			plugin.db.profile.iconDesaturate = defaultDB.iconDesaturate
 		end
-		if not LibSharedMedia:IsValid("font", plugin.db.profile.fontName) or not BigWigsAPI.IsValidMediaPath(LibSharedMedia:Fetch("font", plugin.db.profile.fontName)) then
-			plugin.db.profile.fontName = defaultDB.fontName
-		end
-		if not LibSharedMedia:IsValid("border", plugin.db.profile.borderName) or (plugin.db.profile.borderName ~= "None" and not BigWigsAPI.IsValidMediaPath(LibSharedMedia:Fetch("border", plugin.db.profile.borderName))) then
-			plugin.db.profile.borderName = defaultDB.borderName -- If the border is suddenly invalid then reset the size and offset also
-			plugin.db.profile.borderSize = defaultDB.borderSize
-			plugin.db.profile.borderOffset = defaultDB.borderOffset
-		end
-		if not LibSharedMedia:IsValid("sound", plugin.db.profile.newResAvailableSound) then
-			plugin.db.profile.newResAvailableSound = defaultDB.newResAvailableSound
-		end
 	end
 	ProfileUtils.SetPreset = function(mode)
 		if mode == "icon" then
@@ -423,10 +412,10 @@ do
 		cdTextFormat = plugin.db.profile.durationCustomText:format("%d:%02d")
 		local currentCDText = battleResFrame.cdTextRaw or 0
 		if plugin.db.profile.durationEmphasizeTime > 0 and currentCDText <= plugin.db.profile.durationEmphasizeTime then
-			battleResFrame.cdText:SetFont(LibSharedMedia:Fetch("font", plugin.db.profile.fontName), plugin.db.profile.durationEmphasizeFontSize, fontFlags)
+			battleResFrame.cdText:SetFont(plugin:FetchMedia("font", plugin.db.profile.fontName, plugin.defaultDB.fontName), plugin.db.profile.durationEmphasizeFontSize, fontFlags)
 			battleResFrame.cdText:SetTextColor(plugin.db.profile.durationEmphasizeColor[1], plugin.db.profile.durationEmphasizeColor[2], plugin.db.profile.durationEmphasizeColor[3], plugin.db.profile.durationEmphasizeColor[4])
 		else
-			battleResFrame.cdText:SetFont(LibSharedMedia:Fetch("font", plugin.db.profile.fontName), plugin.db.profile.durationFontSize, fontFlags)
+			battleResFrame.cdText:SetFont(plugin:FetchMedia("font", plugin.db.profile.fontName, plugin.defaultDB.fontName), plugin.db.profile.durationFontSize, fontFlags)
 			battleResFrame.cdText:SetTextColor(plugin.db.profile.durationColor[1], plugin.db.profile.durationColor[2], plugin.db.profile.durationColor[3], plugin.db.profile.durationColor[4])
 		end
 		battleResFrame.cdText:SetText("")
@@ -448,10 +437,10 @@ do
 		chargesTextFormat = plugin.db.profile.chargesCustomText:format("%d")
 		local currentChargesText = battleResFrame.chargesTextRaw or 0
 		if currentChargesText == 0 then
-			battleResFrame.chargesText:SetFont(LibSharedMedia:Fetch("font", plugin.db.profile.fontName), plugin.db.profile.chargesNoneFontSize, fontFlags)
+			battleResFrame.chargesText:SetFont(plugin:FetchMedia("font", plugin.db.profile.fontName, plugin.defaultDB.fontName), plugin.db.profile.chargesNoneFontSize, fontFlags)
 			battleResFrame.chargesText:SetTextColor(plugin.db.profile.chargesNoneColor[1], plugin.db.profile.chargesNoneColor[2], plugin.db.profile.chargesNoneColor[3], plugin.db.profile.chargesNoneColor[4])
 		else
-			battleResFrame.chargesText:SetFont(LibSharedMedia:Fetch("font", plugin.db.profile.fontName), plugin.db.profile.chargesAvailableFontSize, fontFlags)
+			battleResFrame.chargesText:SetFont(plugin:FetchMedia("font", plugin.db.profile.fontName, plugin.defaultDB.fontName), plugin.db.profile.chargesAvailableFontSize, fontFlags)
 			battleResFrame.chargesText:SetTextColor(plugin.db.profile.chargesAvailableColor[1], plugin.db.profile.chargesAvailableColor[2], plugin.db.profile.chargesAvailableColor[3], plugin.db.profile.chargesAvailableColor[4])
 		end
 		battleResFrame.chargesText:SetText("")
@@ -462,7 +451,7 @@ do
 		battleResFrame.cooldown:SetReverse(plugin.db.profile.cooldownInverse)
 
 		battleResFrame.border:SetBackdrop({
-			edgeFile = LibSharedMedia:Fetch("border", plugin.db.profile.borderName),
+			edgeFile = plugin:FetchMedia("border", plugin.db.profile.borderName, plugin.defaultDB.borderName),
 			edgeSize = plugin.db.profile.borderSize,
 		})
 		battleResFrame.border:ClearAllPoints()
@@ -1368,7 +1357,7 @@ do
 			if currentCharges > previousCharges and previousCharges >= 0 then
 				local soundName = plugin.db.profile.newResAvailableSound
 				if soundName ~= "None" then
-					local sound = LibSharedMedia:Fetch("sound", soundName, true)
+					local sound = plugin:FetchMedia("sound", soundName, plugin.defaultDB.newResAvailableSound)
 					if sound then
 						plugin:PlaySoundFile(sound)
 					end
@@ -1551,7 +1540,7 @@ do
 		ProfileUtils.ValidateMainSettings()
 		ProfileUtils.UpdateWidgets()
 		if self.db.profile.newResAvailableSound ~= "None" then
-			local path = LibSharedMedia:Fetch("sound", self.db.profile.newResAvailableSound)
+			local path = self:FetchMedia("sound", self.db.profile.newResAvailableSound, self.defaultDB.newResAvailableSound)
 			self:SimpleTimer(function() local played, id = self:PlaySoundFile(path) if played then StopSound(id) end end, 0)
 		end
 		if not self.db.profile.disabled then

--- a/Plugins/Countdown.lua
+++ b/Plugins/Countdown.lua
@@ -66,7 +66,7 @@ local function UpdateFont()
 	elseif plugin.db.profile.outline ~= "NONE" then
 		flags = plugin.db.profile.outline
 	end
-	countdownText:SetFont(LibSharedMedia:Fetch(FONT, plugin.db.profile.fontName), plugin.db.profile.fontSize, flags)
+	countdownText:SetFont(plugin:FetchMedia(FONT, plugin.db.profile.fontName, plugin.defaultDB.fontName), plugin.db.profile.fontSize, flags)
 	countdownText:SetTextColor(plugin.db.profile.fontColor.r, plugin.db.profile.fontColor.g, plugin.db.profile.fontColor.b)
 end
 
@@ -82,9 +82,6 @@ local function updateProfile()
 		end
 	end
 
-	if not LibSharedMedia:IsValid(FONT, db.fontName) or not BigWigsAPI.IsValidMediaPath(LibSharedMedia:Fetch("font", db.fontName)) then
-		db.fontName = plugin.defaultDB.fontName
-	end
 	if db.outline ~= "NONE" and db.outline ~= "OUTLINE" and db.outline ~= "THICKOUTLINE" then
 		db.outline = plugin.defaultDB.outline
 	end

--- a/Plugins/Messages.lua
+++ b/Plugins/Messages.lua
@@ -100,12 +100,6 @@ local function updateProfile()
 	if db.fadetime < 1 or db.fadetime > 10 then
 		db.fadetime = plugin.defaultDB.fadetime
 	end
-	if not LibSharedMedia:IsValid(FONT, db.fontName) or not BigWigsAPI.IsValidMediaPath(LibSharedMedia:Fetch("font", db.fontName)) then
-		db.fontName = plugin.defaultDB.fontName
-	end
-	if not LibSharedMedia:IsValid(FONT, db.emphFontName) or not BigWigsAPI.IsValidMediaPath(LibSharedMedia:Fetch("font", db.emphFontName)) then
-		db.emphFontName = plugin.defaultDB.emphFontName
-	end
 	if type(db.normalPosition[1]) ~= "string" or type(db.normalPosition[2]) ~= "string"
 	or type(db.normalPosition[3]) ~= "number" or type(db.normalPosition[4]) ~= "number"
 	or not BigWigsAPI.IsValidFramePoint(db.normalPosition[1]) or not BigWigsAPI.IsValidFramePoint(db.normalPosition[2]) then
@@ -156,7 +150,7 @@ local function updateProfile()
 			emphFlags = emphFlags .. ",SLUG"
 		end
 	end
-	emphMessageText:SetFont(LibSharedMedia:Fetch(FONT, db.emphFontName), db.emphFontSize, emphFlags)
+	emphMessageText:SetFont(plugin:FetchMedia(FONT, db.emphFontName, plugin.defaultDB.emphFontName), db.emphFontSize, emphFlags)
 
 	normalMessageAnchor:RefixPosition()
 	emphMessageAnchor:RefixPosition()
@@ -192,7 +186,7 @@ local function updateProfile()
 		font.icon.animFade:SetDuration(db.fadetime)
 		font.icon:SetSize(db.fontSize, db.fontSize)
 		font:SetHeight(db.fontSize)
-		font:SetFont(LibSharedMedia:Fetch(FONT, db.fontName), db.fontSize, flags)
+		font:SetFont(plugin:FetchMedia(FONT, db.fontName, plugin.defaultDB.fontName), db.fontSize, flags)
 	end
 end
 

--- a/Plugins/Nameplates.lua
+++ b/Plugins/Nameplates.lua
@@ -256,9 +256,6 @@ do
 		if db.iconOffsetYTarget < -100 or db.iconOffsetYTarget > 100 then
 			db.iconOffsetYTarget = plugin.defaultDB.iconOffsetYTarget
 		end
-		if not LibSharedMedia:IsValid(FONT, db.iconFontName) or not BigWigsAPI.IsValidMediaPath(LibSharedMedia:Fetch("font", db.iconFontName)) then
-			db.iconFontName = plugin.defaultDB.iconFontName
-		end
 		if db.iconFontSize < 6 or db.iconFontSize > 200 then
 			db.iconFontSize = plugin.defaultDB.iconFontSize
 		end
@@ -304,11 +301,6 @@ do
 		end
 		ValidateColor(db.iconColor, plugin.defaultDB.iconColor, 0.3)
 		ValidateColor(db.iconGlowColor, plugin.defaultDB.iconGlowColor, 0)
-		if not LibSharedMedia:IsValid("border", db.iconBorderName) or (db.iconBorderName ~= "None" and not BigWigsAPI.IsValidMediaPath(LibSharedMedia:Fetch("border", db.iconBorderName))) then
-			db.iconBorderName = plugin.defaultDB.iconBorderName
-			db.iconBorderSize = plugin.defaultDB.iconBorderSize
-			db.iconBorderOffset = plugin.defaultDB.iconBorderOffset
-		end
 		if db.iconBorderSize < 1 or db.iconBorderSize > 32 then
 			db.iconBorderSize = plugin.defaultDB.iconBorderSize
 		end
@@ -342,9 +334,6 @@ do
 		if db.textOffsetY < -150 or db.textOffsetY > 150 then
 			db.textOffsetY = plugin.defaultDB.textOffsetY
 		end
-		if not LibSharedMedia:IsValid(FONT, db.textFontName) or not BigWigsAPI.IsValidMediaPath(db.textFontName) then
-			db.textFontName = plugin.defaultDB.textFontName
-		end
 		if db.textFontSize < 10 or db.textFontSize > 200 then
 			db.textFontSize = plugin.defaultDB.textFontSize
 		end
@@ -354,7 +343,7 @@ do
 		end
 
 		iconBorderTable = {
-			edgeFile = LibSharedMedia:Fetch("border", db.iconBorderName),
+			edgeFile = plugin:FetchMedia("border", db.iconBorderName, plugin.defaultDB.iconBorderName),
 			edgeSize = db.iconBorderSize,
 		}
 	end
@@ -406,7 +395,7 @@ local function getTextFrame()
 		elseif db.textOutline ~= "NONE" then
 			flags = db.textOutline
 		end
-		self.fontString:SetFont(LibSharedMedia:Fetch(FONT, db.textFontName), db.textFontSize, flags)
+		self.fontString:SetFont(plugin:FetchMedia(FONT, db.textFontName, plugin.defaultDB.textFontName), db.textFontSize, flags)
 		self.fontString:SetTextColor(db.textFontColor[1], db.textFontColor[2], db.textFontColor[3], db.textFontColor[4])
 		local w, h = self.fontString:GetWidth(), self.fontString:GetHeight()
 		self:SetSize(w, h)
@@ -475,7 +464,7 @@ local function iconLoop(updater)
 			elseif db.iconFontOutline ~= "NONE" then
 				flags = db.iconFontOutline
 			end
-			iconFrame.countdownNumber:SetFont(LibSharedMedia:Fetch(FONT, db.iconFontName), db.iconEmphasizeFontSize, flags)
+			iconFrame.countdownNumber:SetFont(plugin:FetchMedia(FONT, db.iconFontName, plugin.defaultDB.iconFontName), db.iconEmphasizeFontSize, flags)
 			iconFrame.countdownNumber:SetTextColor(db.iconEmphasizeFontColor[1], db.iconEmphasizeFontColor[2], db.iconEmphasizeFontColor[3], db.iconEmphasizeFontColor[4])
 		end
 		if db.iconCooldownNumbers then
@@ -587,10 +576,10 @@ local function getIconFrame()
 
 				local timeToDisplay = math.ceil(remaining)
 				if timeToDisplay <= db.iconEmphasizeTime then
-					self.countdownNumber:SetFont(LibSharedMedia:Fetch(FONT, db.iconFontName), db.iconEmphasizeFontSize, flags)
+					self.countdownNumber:SetFont(plugin:FetchMedia(FONT, db.iconFontName, plugin.defaultDB.iconFontName), db.iconEmphasizeFontSize, flags)
 					self.countdownNumber:SetTextColor(db.iconEmphasizeFontColor[1], db.iconEmphasizeFontColor[2], db.iconEmphasizeFontColor[3], db.iconEmphasizeFontColor[4])
 				else
-					self.countdownNumber:SetFont(LibSharedMedia:Fetch(FONT, db.iconFontName), db.iconFontSize, flags)
+					self.countdownNumber:SetFont(plugin:FetchMedia(FONT, db.iconFontName, plugin.defaultDB.iconFontName), db.iconFontSize, flags)
 					self.countdownNumber:SetTextColor(db.iconFontColor[1], db.iconFontColor[2], db.iconFontColor[3], db.iconFontColor[4])
 				end
 
@@ -1070,7 +1059,7 @@ do
 								set = function(_, value)
 									db.iconBorderSize = value
 									iconBorderTable = {
-										edgeFile = LibSharedMedia:Fetch("border", db.iconBorderName),
+										edgeFile = plugin:FetchMedia("border", db.iconBorderName, plugin.defaultDB.iconBorderName),
 										edgeSize = value,
 									}
 									resetNameplates()
@@ -1101,7 +1090,7 @@ do
 									local list = LibSharedMedia:List("border")
 									db.iconBorderName = list[value]
 									iconBorderTable = {
-										edgeFile = LibSharedMedia:Fetch("border", db.iconBorderName),
+										edgeFile = plugin:FetchMedia("border", db.iconBorderName, plugin.defaultDB.iconBorderName),
 										edgeSize = db.iconBorderSize,
 									}
 									resetNameplates()

--- a/Plugins/Pull.lua
+++ b/Plugins/Pull.lua
@@ -277,15 +277,6 @@ do
 		if not BigWigsAPI:HasCountdown(db.voice) then
 			db.voice = plugin.defaultDB.voice
 		end
-		if not LibSharedMedia:IsValid(SOUND, db.engageSound) then
-			db.engageSound = plugin.defaultDB.engageSound
-		end
-		if not LibSharedMedia:IsValid(SOUND, db.startPullSound) then
-			db.startPullSound = plugin.defaultDB.startPullSound
-		end
-		if not LibSharedMedia:IsValid(SOUND, db.endPullSound) then
-			db.endPullSound = plugin.defaultDB.endPullSound
-		end
 
 		if not InCombatLockdown() then
 			ClearOverrideBindings(BWPull)
@@ -374,7 +365,7 @@ do
 			end
 			local soundName = plugin.db.profile.endPullSound
 			if soundName ~= "None" then
-				local sound = LibSharedMedia:Fetch(SOUND, soundName, true)
+				local sound = plugin:FetchMedia(SOUND, soundName, plugin.defaultDB.endPullSound)
 				if sound then
 					plugin:PlaySoundFile(sound)
 				end
@@ -430,7 +421,7 @@ do
 		self:SendMessage("BigWigs_StartPull", self, timeSeconds, name, L.pull, 132337)
 		local soundName = self.db.profile.startPullSound
 		if soundName ~= "None" then
-			local sound = LibSharedMedia:Fetch(SOUND, soundName, true)
+			local sound = plugin:FetchMedia(SOUND, soundName, plugin.defaultDB.startPullSound)
 			if sound then
 				self:PlaySoundFile(sound)
 			end
@@ -496,7 +487,7 @@ function plugin:BigWigs_OnBossEngage(_, module)
 	if module and (module:GetJournalID() or module:GetAllowWin()) then
 		local soundName = self.db.profile.engageSound
 		if soundName ~= "None" then
-			local sound = LibSharedMedia:Fetch(SOUND, soundName, true)
+			local sound = plugin:FetchMedia(SOUND, soundName, plugin.defaultDB.engageSound)
 			if sound then
 				self:PlaySoundFile(sound)
 			end

--- a/Plugins/Sound.lua
+++ b/Plugins/Sound.lua
@@ -63,7 +63,6 @@ plugin.defaultDB = {
 
 local function updateProfile()
 	db = plugin.db.profile
-	local printTbl, blockedFromPrints = {}, {}
 	for k, v in next, db do
 		local defaultType = type(plugin.defaultDB[k])
 		if defaultType == "nil" then
@@ -73,17 +72,12 @@ local function updateProfile()
 		elseif sounds[k] then
 			for bossModuleName, soundTbl in next, v do
 				for optionKey, soundName in next, soundTbl do
-					if not LibSharedMedia:IsValid("sound", soundName) then
-						soundTbl[optionKey] = nil -- Invalid sound, remove
-						if not blockedFromPrints[soundName] then
-							blockedFromPrints[soundName] = true
-							local moduleName = bossModuleName:sub(16) -- Remove "BigWigs_Bosses_" text
-							printTbl[#printTbl+1] = L.soundResetPrint:format(moduleName, soundName)
-						end
+					if type(soundName) ~= "string" then
+						soundTbl[optionKey] = nil
 					end
 				end
 				if not next(soundTbl) then
-					db[k][bossModuleName] = nil -- Sounds list for this boss module is an empty table, remove it
+					db[k][bossModuleName] = nil
 				end
 			end
 		end
@@ -95,21 +89,7 @@ local function updateProfile()
 			db.media[k] = nil
 		elseif type(v) ~= defaultType then
 			db.media[k] = plugin.defaultDB.media[k] -- Invalid type, reset
-		elseif not LibSharedMedia:IsValid("sound", v) then
-			db.media[k] = plugin.defaultDB.media[k] -- Invalid sound, reset
-			if not blockedFromPrints[v] then
-				blockedFromPrints[v] = true
-				printTbl[#printTbl+1] = L.soundResetPrint:format(plugin.moduleName, v)
-			end
 		end
-	end
-
-	if printTbl[1] then
-		plugin:SimpleTimer(function()
-			for i = 1, #printTbl do
-				plugin:Print(printTbl[i])
-			end
-		end, 0)
 	end
 end
 
@@ -602,14 +582,12 @@ do
 	function plugin:GetSoundFile(module, key, soundName)
 		soundName = tmp[soundName] or soundName
 		local sDb = db[soundName]
-		if not module or not key or not sDb or not sDb[module.name] or not sDb[module.name][key] then
-			local path = db.media[soundName] and LibSharedMedia:Fetch(SOUND, db.media[soundName], true) or LibSharedMedia:Fetch(SOUND, soundName, true)
-			return path
-		else
-			local newSound = sDb[module.name][key]
-			local path = db.media[newSound] and LibSharedMedia:Fetch(SOUND, db.media[newSound], true) or LibSharedMedia:Fetch(SOUND, newSound, true)
-			return path
+		if module and key and sDb and sDb[module.name] and sDb[module.name][key] then
+			local custom = sDb[module.name][key]
+			local path = self:FetchMedia(SOUND, db.media[custom] or custom, sounds[custom])
+			if path then return path end
 		end
+		return self:FetchMedia(SOUND, db.media[soundName] or soundName, sounds[soundName])
 	end
 
 	function plugin:GetDefaultSound(soundName)
@@ -628,7 +606,7 @@ do
 
 	function plugin:GetDefaultSoundFile(soundName)
 		local defaultSound = self:GetDefaultSound(soundName)
-		return defaultSound and LibSharedMedia:Fetch(SOUND, defaultSound, true)
+		return defaultSound and self:FetchMedia(SOUND, defaultSound, sounds[tmp[soundName] or soundName])
 	end
 end
 

--- a/Plugins/Victory.lua
+++ b/Plugins/Victory.lua
@@ -114,10 +114,6 @@ do
 			end
 		end
 
-		if not LibSharedMedia:IsValid("sound", db.soundName) then
-			db.soundName = plugin.defaultDB.soundName
-		end
-
 		if not db.blizzVictory and type(BossBanner) == "table" and BossBanner:IsEventRegistered("BOSS_KILL") then
 			shouldRestoreBanner = true
 			BossBanner:UnregisterEvent("BOSS_KILL")
@@ -127,7 +123,7 @@ do
 	function plugin:OnPluginEnable()
 		updateProfile()
 		if self.db.profile.soundName ~= "None" then
-			self:SimpleTimer(function() local played, id = self:PlaySoundFile(LibSharedMedia:Fetch(SOUND, self.db.profile.soundName)) if played then StopSound(id) end end, 0)
+			self:SimpleTimer(function() local played, id = self:PlaySoundFile(self:FetchMedia(SOUND, self.db.profile.soundName, self.defaultDB.soundName)) if played then StopSound(id) end end, 0)
 		end
 
 		self:RegisterMessage("BigWigs_OnBossWin")
@@ -163,7 +159,7 @@ do
 			prev = t
 			local soundName = self.db.profile.soundName
 			if soundName ~= "None" then
-				local sound = LibSharedMedia:Fetch(SOUND, soundName, true)
+				local sound = plugin:FetchMedia(SOUND, soundName, plugin.defaultDB.soundName)
 				if sound then
 					self:PlaySoundFile(sound)
 				end

--- a/Plugins/Wipe.lua
+++ b/Plugins/Wipe.lua
@@ -83,10 +83,6 @@ do
 				db[k] = plugin.defaultDB[k]
 			end
 		end
-
-		if not LibSharedMedia:IsValid("sound", db.wipeSound) then
-			db.wipeSound = plugin.defaultDB.wipeSound
-		end
 	end
 
 	function plugin:OnPluginEnable()
@@ -111,7 +107,7 @@ function plugin:BigWigs_EncounterEnd(_, module, _, _, _, _, status)
 		if module:GetJournalID() or module:GetAllowWin() then
 			local soundName = self.db.profile.wipeSound
 			if soundName ~= "None" then
-				local sound = LibSharedMedia:Fetch(SOUND, soundName, true)
+				local sound = plugin:FetchMedia(SOUND, soundName, plugin.defaultDB.wipeSound)
 				if sound then
 					self:PlaySoundFile(sound)
 				end


### PR DESCRIPTION
Selecting media supplied by another addon, loading BigWigs while that addon is disabled or uninstalled, and then reinstalling it currently loses the selection: profile validation replaces missing media with defaults or deletes per-boss sound overrides.

Remove these automatic missing-media resets for fonts, statusbar textures, borders, and sounds across the plugins. Missing borders also no longer reset their saved size and offset. Resolve unavailable media to a temporary runtime fallback without changing the saved selection, so the original choice works again when the provider returns. Explicit user resets and malformed-setting validation remain intact.

Validation:
- Lua 5.1 syntax and Luacheck 1.2.0 with the repository configuration pass for all 11 changed files (zero warnings/errors).
- An isolated Lua check using LibSharedMedia and the changed source functions covers removal/reinstallation, registered paths with missing files, `None`, global overrides, per-boss/global sound fallbacks, and malformed settings. The upstream baseline resets the same missing sound selections; this change preserves them.
- Audited the remaining LSM validity checks: only explicit bar-style application checks remain. `git diff --check` passes.
- Not tested in-game. Manual verification: select third-party media, disable its provider and reload, then re-enable it and reload; the original selections should return without reselecting them.
